### PR TITLE
Fix Router Type Inconsistency in API

### DIFF
--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -81,6 +81,12 @@ type RevokeUserRequest struct {
 	Email string `json:"email"`
 }
 
+// RevokeUserResponse represents the response after revoking a user
+type RevokeUserResponse struct {
+	Message string `json:"message"`
+	Email   string `json:"email"`
+}
+
 // HealthResponse represents the response to a health check request
 type HealthResponse struct {
 	Status  string `json:"status"`

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"runvoy/internal/api"
 	"runvoy/internal/config"
 )
 
@@ -107,10 +108,7 @@ func (c *Client) DoJSON(ctx context.Context, req Request, result interface{}) er
 
 	// Check for error responses
 	if resp.StatusCode >= 400 {
-		var errorResp struct {
-			Error   string `json:"error"`
-			Details string `json:"details"`
-		}
+		var errorResp api.ErrorResponse
 		if err := json.Unmarshal(resp.Body, &errorResp); err != nil {
 			return fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(resp.Body))
 		}
@@ -124,4 +122,45 @@ func (c *Client) DoJSON(ctx context.Context, req Request, result interface{}) er
 	}
 
 	return nil
+}
+
+// CreateUser creates a new user using the API
+func (c *Client) CreateUser(ctx context.Context, req api.CreateUserRequest) (*api.CreateUserResponse, error) {
+	var resp api.CreateUserResponse
+	err := c.DoJSON(ctx, Request{
+		Method: "POST",
+		Path:   "/api/v1/users/create",
+		Body:   req,
+	}, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// RevokeUser revokes a user's API key
+func (c *Client) RevokeUser(ctx context.Context, req api.RevokeUserRequest) (*api.RevokeUserResponse, error) {
+	var resp api.RevokeUserResponse
+	err := c.DoJSON(ctx, Request{
+		Method: "POST",
+		Path:   "/api/v1/users/revoke",
+		Body:   req,
+	}, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetHealth checks the API health status
+func (c *Client) GetHealth(ctx context.Context) (*api.HealthResponse, error) {
+	var resp api.HealthResponse
+	err := c.DoJSON(ctx, Request{
+		Method: "GET",
+		Path:   "/api/v1/health",
+	}, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -75,9 +75,9 @@ func (rw *responseWriter) Write(b []byte) (int, error) {
 // handleHealth returns a simple health check response
 func (r *Router) handleHealth(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{
-		"status":  "ok",
-		"version": *constants.GetVersion(),
+	json.NewEncoder(w).Encode(api.HealthResponse{
+		Status:  "ok",
+		Version: *constants.GetVersion(),
 	})
 }
 
@@ -175,9 +175,9 @@ func (r *Router) handleRevokeUser(w http.ResponseWriter, req *http.Request) {
 
 	// Return successful response
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{
-		"message": "User API key revoked successfully",
-		"email":   revokeReq.Email,
+	json.NewEncoder(w).Encode(api.RevokeUserResponse{
+		Message: "User API key revoked successfully",
+		Email:   revokeReq.Email,
 	})
 }
 


### PR DESCRIPTION
This commit ensures that client and server share a consistent type contract by:

1. Added RevokeUserResponse type to api/types.go for consistent revoke response format
2. Updated handleHealth to use api.HealthResponse instead of inline map
3. Updated handleRevokeUser to use api.RevokeUserResponse instead of inline map
4. Updated client error handling to use api.ErrorResponse instead of inline struct
5. Added typed client methods (CreateUser, RevokeUser, GetHealth) that use the shared API types

Benefits:
- Type safety: Compile-time checking ensures client/server agreement
- Better IDE support: Autocomplete and type hints for API structures
- Single source of truth: API types defined once in internal/api/types.go
- Easier refactoring: Changes to API types propagate automatically
- Self-documenting: API contract is explicit and visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)