### PR TITLE
Address ecs/fargate task definition mismatch

### DIFF
--- a/cmd/runvoy/cmd/admin.go
+++ b/cmd/runvoy/cmd/admin.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"fmt"
+	"log/slog"
+
+	"runvoy/internal/api"
+	"runvoy/internal/client"
+	"runvoy/internal/constants"
+	"runvoy/internal/output"
+
+	"github.com/spf13/cobra"
+)
+
+var adminCmd = &cobra.Command{
+	Use:   "admin",
+	Short: "Admin commands",
+	Long:  "Administrative commands for managing runvoy",
+}
+
+var imagesCmd = &cobra.Command{
+	Use:   "images",
+	Short: "Image management commands",
+	Long:  "Manage Docker images for task definitions",
+}
+
+var registerImageCmd = &cobra.Command{
+	Use:   "register <image>",
+	Short: "Register a Docker image for use in task definitions",
+	Long:  `Register a Docker image so it can be used when running commands. Optionally specify --with-git to enable git repository cloning support.`,
+	Example: fmt.Sprintf(`  - %s admin images register ubuntu:22.04
+  - %s admin images register node:20 --with-git
+  - %s admin images register public.ecr.aws/docker/library/python:3.11`, constants.ProjectName, constants.ProjectName, constants.ProjectName),
+	Run:  runRegisterImage,
+	Args: cobra.ExactArgs(1),
+}
+
+var withGit bool
+
+func init() {
+	registerImageCmd.Flags().BoolVar(&withGit, "with-git", false, "Enable git repository cloning support for this image")
+	imagesCmd.AddCommand(registerImageCmd)
+	adminCmd.AddCommand(imagesCmd)
+	rootCmd.AddCommand(adminCmd)
+}
+
+func runRegisterImage(cmd *cobra.Command, args []string) {
+	cfg, err := getConfigFromContext(cmd)
+	if err != nil {
+		output.Errorf("failed to load configuration: %v", err)
+		return
+	}
+	image := args[0]
+
+	output.Infof("Registering image %s...", image)
+	if withGit {
+		output.Infof("  Git repository support: enabled")
+	}
+
+	client := client.New(cfg, slog.Default())
+	resp, err := client.RegisterImage(cmd.Context(), api.RegisterImageRequest{
+		Image:   image,
+		WithGit: withGit,
+	})
+	if err != nil {
+		output.Errorf(err.Error())
+		return
+	}
+
+	output.Successf("Image registered successfully")
+	output.KeyValue("Image", resp.TaskDefinition.Image)
+	output.KeyValue("Git Support", fmt.Sprintf("%v", resp.TaskDefinition.HasGit))
+	output.KeyValue("Task Definition ARN", resp.TaskDefinition.TaskDefinitionARN)
+	output.KeyValue("Task Key", resp.TaskDefinition.TaskKey)
+}

--- a/deployments/cloudformation-backend.yaml
+++ b/deployments/cloudformation-backend.yaml
@@ -138,6 +138,26 @@ Resources:
         - Key: ManagedBy
           Value: 'cloudformation'
 
+  # DynamoDB Table for Task Definition Registry
+  TaskDefinitionsTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub '${ProjectName}-task-definitions'
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: task_key
+          AttributeType: S
+      KeySchema:
+        - AttributeName: task_key
+          KeyType: HASH
+      Tags:
+        - Key: Name
+          Value: !Sub '${ProjectName}-task-definitions'
+        - Key: Application
+          Value: !Ref ProjectName
+        - Key: ManagedBy
+          Value: 'cloudformation'
+
   # CloudWatch Log Group for ECS task runner logs
   RunnerLogGroup:
     Type: AWS::Logs::LogGroup
@@ -539,6 +559,7 @@ Resources:
                   - !GetAtt ExecutionsTable.Arn
                   - !GetAtt LocksTable.Arn
                   - !GetAtt PendingAPIKeysTable.Arn
+                  - !GetAtt TaskDefinitionsTable.Arn
                   - !Sub '${APIKeysTable.Arn}/index/*'
                   - !Sub '${ExecutionsTable.Arn}/index/*'
 
@@ -570,6 +591,7 @@ Resources:
           RUNVOY_EXECUTIONS_TABLE: !Ref ExecutionsTable
           RUNVOY_LOCKS_TABLE: !Ref LocksTable
           RUNVOY_PENDING_API_KEYS_TABLE: !Ref PendingAPIKeysTable
+          RUNVOY_TASK_DEFINITIONS_TABLE: !Ref TaskDefinitionsTable
           RUNVOY_ECS_CLUSTER: !Ref ECSCluster
           RUNVOY_TASK_DEFINITION: !Ref TaskDefinition
           RUNVOY_TASK_DEFINITION_WITH_GIT: !Ref TaskDefinitionWithGit
@@ -736,6 +758,12 @@ Outputs:
     Value: !Ref PendingAPIKeysTable
     Export:
       Name: !Sub '${ProjectName}-pending-api-keys-table'
+
+  TaskDefinitionsTableName:
+    Description: DynamoDB Task Definitions Registry Table name
+    Value: !Ref TaskDefinitionsTable
+    Export:
+      Name: !Sub '${ProjectName}-task-definitions-table'
 
   ECSClusterName:
     Description: ECS Cluster name

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -146,3 +146,26 @@ type HealthResponse struct {
 	Status  string `json:"status"`
 	Version string `json:"version"`
 }
+
+// TaskDefinition represents a registered task definition in the registry
+type TaskDefinition struct {
+	TaskKey           string    `json:"task_key"`
+	Image             string    `json:"image"`
+	HasGit            bool      `json:"has_git"`
+	TaskDefinitionARN string    `json:"task_definition_arn"`
+	CreatedAt         time.Time `json:"created_at"`
+	LastUsed          time.Time `json:"last_used,omitempty"`
+	CreatedBy         string    `json:"created_by,omitempty"`
+}
+
+// RegisterImageRequest represents the request to register a new Docker image
+type RegisterImageRequest struct {
+	Image   string `json:"image"`   // Docker image name (e.g., "ubuntu:22.04")
+	WithGit bool   `json:"with_git"` // Whether to register with git sidecar support
+}
+
+// RegisterImageResponse represents the response after registering an image
+type RegisterImageResponse struct {
+	TaskDefinition *TaskDefinition `json:"task_definition"`
+	Message        string          `json:"message"`
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -255,3 +255,17 @@ func (c *Client) ClaimAPIKey(ctx context.Context, token string) (*api.ClaimAPIKe
 	}
 	return &resp, nil
 }
+
+// RegisterImage registers a Docker image for use in task definitions
+func (c *Client) RegisterImage(ctx context.Context, req api.RegisterImageRequest) (*api.RegisterImageResponse, error) {
+	var resp api.RegisterImageResponse
+	err := c.DoJSON(ctx, Request{
+		Method: "POST",
+		Path:   "/api/v1/admin/images/register",
+		Body:   req,
+	}, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,7 +29,8 @@ type Config struct {
 	RequestTimeout        time.Duration `mapstructure:"request_timeout"`
 	APIKeysTable          string        `mapstructure:"api_keys_table"`
 	ExecutionsTable       string        `mapstructure:"executions_table"`
-	PendingAPIKeysTable   string        `mapstructure:"pending_api_keys_table"`
+	PendingAPIKeysTable string        `mapstructure:"pending_api_keys_table"`
+	TaskDefinitionsTable  string        `mapstructure:"task_definitions_table"`
 	ECSCluster            string        `mapstructure:"ecs_cluster"`
 	TaskDefinition        string        `mapstructure:"task_definition"`
 	TaskDefinitionWithGit string        `mapstructure:"task_definition_with_git"`
@@ -265,6 +266,7 @@ func bindEnvVars(v *viper.Viper) {
 		"API_KEYS_TABLE",
 		"EXECUTIONS_TABLE",
 		"PENDING_API_KEYS_TABLE",
+		"TASK_DEFINITIONS_TABLE",
 		"ECS_CLUSTER",
 		"TASK_DEFINITION",
 		"TASK_DEFINITION_WITH_GIT",

--- a/internal/database/dynamodb/taskdefs.go
+++ b/internal/database/dynamodb/taskdefs.go
@@ -1,0 +1,215 @@
+package dynamodb
+
+import (
+	"context"
+	stderrors "errors"
+	"log/slog"
+	"time"
+
+	"runvoy/internal/api"
+	apperrors "runvoy/internal/errors"
+	"runvoy/internal/logger"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+// TaskDefinitionRepository implements task definition registry operations using DynamoDB.
+type TaskDefinitionRepository struct {
+	client    *dynamodb.Client
+	tableName string
+	logger    *slog.Logger
+}
+
+// NewTaskDefinitionRepository creates a new DynamoDB-backed task definition repository.
+func NewTaskDefinitionRepository(client *dynamodb.Client, tableName string, logger *slog.Logger) *TaskDefinitionRepository {
+	return &TaskDefinitionRepository{
+		client:    client,
+		tableName: tableName,
+		logger:    logger,
+	}
+}
+
+// taskDefinitionItem represents the structure stored in DynamoDB.
+type taskDefinitionItem struct {
+	TaskKey          string    `dynamodbav:"task_key"`          // Hash of (image + hasGit)
+	Image            string    `dynamodbav:"image"`             // Docker image name
+	HasGit           bool      `dynamodbav:"has_git"`           // Whether this task def supports git
+	TaskDefinitionARN string    `dynamodbav:"task_definition_arn"` // ECS task definition ARN
+	CreatedAt        time.Time `dynamodbav:"created_at"`        // When this was registered
+	LastUsed         time.Time `dynamodbav:"last_used,omitempty"` // Last time this was used
+	CreatedBy        string    `dynamodbav:"created_by,omitempty"` // User who registered it (optional)
+}
+
+// GetTaskDefinition retrieves a task definition by its key (image + hasGit hash).
+func (r *TaskDefinitionRepository) GetTaskDefinition(ctx context.Context, taskKey string) (*api.TaskDefinition, error) {
+	reqLogger := logger.DeriveRequestLogger(ctx, r.logger)
+
+	// Log before calling DynamoDB GetItem
+	logArgs := []any{
+		"operation", "DynamoDB.GetItem",
+		"table", r.tableName,
+		"taskKey", taskKey,
+	}
+	logArgs = append(logArgs, logger.GetDeadlineInfo(ctx)...)
+	reqLogger.Debug("calling external service", "context", logger.SliceToMap(logArgs))
+
+	result, err := r.client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(r.tableName),
+		Key: map[string]types.AttributeValue{
+			"task_key": &types.AttributeValueMemberS{Value: taskKey},
+		},
+	})
+
+	if err != nil {
+		reqLogger.Debug("failed to get task definition", "error", err)
+		return nil, apperrors.ErrDatabaseError("failed to get task definition", err)
+	}
+
+	if result.Item == nil {
+		reqLogger.Debug("task definition not found", "taskKey", taskKey)
+		return nil, nil
+	}
+
+	var item taskDefinitionItem
+	if err := attributevalue.UnmarshalMap(result.Item, &item); err != nil {
+		return nil, apperrors.ErrInternalError("failed to unmarshal task definition", err)
+	}
+
+	return &api.TaskDefinition{
+		TaskKey:          item.TaskKey,
+		Image:            item.Image,
+		HasGit:           item.HasGit,
+		TaskDefinitionARN: item.TaskDefinitionARN,
+		CreatedAt:        item.CreatedAt,
+		LastUsed:         item.LastUsed,
+		CreatedBy:        item.CreatedBy,
+	}, nil
+}
+
+// CreateTaskDefinition stores a new task definition registry entry.
+func (r *TaskDefinitionRepository) CreateTaskDefinition(ctx context.Context, taskDef *api.TaskDefinition) error {
+	reqLogger := logger.DeriveRequestLogger(ctx, r.logger)
+
+	// Create the item to store
+	item := taskDefinitionItem{
+		TaskKey:           taskDef.TaskKey,
+		Image:             taskDef.Image,
+		HasGit:            taskDef.HasGit,
+		TaskDefinitionARN: taskDef.TaskDefinitionARN,
+		CreatedAt:         taskDef.CreatedAt,
+		CreatedBy:         taskDef.CreatedBy,
+	}
+
+	av, err := attributevalue.MarshalMap(item)
+	if err != nil {
+		return apperrors.ErrInternalError("failed to marshal task definition", err)
+	}
+
+	// Log before calling DynamoDB PutItem
+	logArgs := []any{
+		"operation", "DynamoDB.PutItem",
+		"table", r.tableName,
+		"taskKey", taskDef.TaskKey,
+		"image", taskDef.Image,
+		"hasGit", taskDef.HasGit,
+	}
+	logArgs = append(logArgs, logger.GetDeadlineInfo(ctx)...)
+	reqLogger.Debug("calling external service", "context", logger.SliceToMap(logArgs))
+
+	// Use ConditionExpression to ensure we don't overwrite existing entries
+	_, err = r.client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName:           aws.String(r.tableName),
+		Item:                av,
+		ConditionExpression: aws.String("attribute_not_exists(task_key)"),
+	})
+
+	if err != nil {
+		var ccf *types.ConditionalCheckFailedException
+		if stderrors.As(err, &ccf) {
+			return apperrors.ErrConflict("task definition with this key already exists", nil)
+		}
+		return apperrors.ErrDatabaseError("failed to create task definition", err)
+	}
+
+	return nil
+}
+
+// UpdateLastUsed updates the last_used timestamp for a task definition.
+func (r *TaskDefinitionRepository) UpdateLastUsed(ctx context.Context, taskKey string) error {
+	reqLogger := logger.DeriveRequestLogger(ctx, r.logger)
+
+	now := time.Now().UTC()
+
+	// Log before calling DynamoDB UpdateItem
+	logArgs := []any{
+		"operation", "DynamoDB.UpdateItem",
+		"table", r.tableName,
+		"taskKey", taskKey,
+	}
+	logArgs = append(logArgs, logger.GetDeadlineInfo(ctx)...)
+	reqLogger.Debug("calling external service", "context", logger.SliceToMap(logArgs))
+
+	_, err := r.client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(r.tableName),
+		Key: map[string]types.AttributeValue{
+			"task_key": &types.AttributeValueMemberS{Value: taskKey},
+		},
+		UpdateExpression: aws.String("SET last_used = :now"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":now": &types.AttributeValueMemberS{
+				Value: now.Format(time.RFC3339Nano),
+			},
+		},
+	})
+
+	if err != nil {
+		return apperrors.ErrDatabaseError("failed to update last_used", err)
+	}
+
+	return nil
+}
+
+// ListTaskDefinitions returns all registered task definitions.
+func (r *TaskDefinitionRepository) ListTaskDefinitions(ctx context.Context) ([]*api.TaskDefinition, error) {
+	reqLogger := logger.DeriveRequestLogger(ctx, r.logger)
+
+	// Log before calling DynamoDB Scan
+	logArgs := []any{
+		"operation", "DynamoDB.Scan",
+		"table", r.tableName,
+	}
+	logArgs = append(logArgs, logger.GetDeadlineInfo(ctx)...)
+	reqLogger.Debug("calling external service", "context", logger.SliceToMap(logArgs))
+
+	result, err := r.client.Scan(ctx, &dynamodb.ScanInput{
+		TableName: aws.String(r.tableName),
+	})
+
+	if err != nil {
+		return nil, apperrors.ErrDatabaseError("failed to list task definitions", err)
+	}
+
+	var taskDefs []*api.TaskDefinition
+	for _, item := range result.Items {
+		var dbItem taskDefinitionItem
+		if err := attributevalue.UnmarshalMap(item, &dbItem); err != nil {
+			reqLogger.Warn("failed to unmarshal task definition item", "error", err)
+			continue
+		}
+
+		taskDefs = append(taskDefs, &api.TaskDefinition{
+			TaskKey:           dbItem.TaskKey,
+			Image:             dbItem.Image,
+			HasGit:            dbItem.HasGit,
+			TaskDefinitionARN: dbItem.TaskDefinitionARN,
+			CreatedAt:         dbItem.CreatedAt,
+			LastUsed:          dbItem.LastUsed,
+			CreatedBy:         dbItem.CreatedBy,
+		})
+	}
+
+	return taskDefs, nil
+}

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -71,3 +71,18 @@ type ExecutionRepository interface {
 	// Implementations may choose an efficient retrieval strategy; order is newest first.
 	ListExecutions(ctx context.Context) ([]*api.Execution, error)
 }
+
+// TaskDefinitionRepository defines the interface for task definition registry operations.
+type TaskDefinitionRepository interface {
+	// GetTaskDefinition retrieves a task definition by its key (hash of image + hasGit).
+	GetTaskDefinition(ctx context.Context, taskKey string) (*api.TaskDefinition, error)
+
+	// CreateTaskDefinition stores a new task definition registry entry.
+	CreateTaskDefinition(ctx context.Context, taskDef *api.TaskDefinition) error
+
+	// UpdateLastUsed updates the last_used timestamp for a task definition.
+	UpdateLastUsed(ctx context.Context, taskKey string) error
+
+	// ListTaskDefinitions returns all registered task definitions.
+	ListTaskDefinitions(ctx context.Context) ([]*api.TaskDefinition, error)
+}

--- a/internal/server/handlers_status_test.go
+++ b/internal/server/handlers_status_test.go
@@ -18,7 +18,7 @@ func TestGetExecutionStatus_Unauthorized(t *testing.T) {
 	_ = rlogger.Initialize(constants.Development, slog.LevelInfo)
 
 	// Build a minimal service with nil repos; we won't reach the handler due to auth
-	svc := app.NewService(nil, nil, nil, nil, slog.Default(), constants.AWS)
+	svc := app.NewService(nil, nil, nil, nil, nil, slog.Default(), constants.AWS)
 	router := NewRouter(svc, 2*time.Second)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/executions/exec-123/status", nil)

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -30,7 +30,7 @@ func TestRequestIDMiddleware(t *testing.T) {
 		rr := httptest.NewRecorder()
 
 		// Create a Router with a test service for the middleware
-		svc := app.NewService(nil, nil, nil, nil, slog.Default(), constants.AWS)
+		svc := app.NewService(nil, nil, nil, nil, nil, slog.Default(), constants.AWS)
 		router := &Router{svc: svc}
 		middleware := router.requestIDMiddleware(handler)
 		middleware.ServeHTTP(rr, req)
@@ -62,7 +62,7 @@ func TestRequestIDMiddleware(t *testing.T) {
 		req = req.WithContext(ctx)
 
 		// Create a Router with a test service for the middleware
-		svc := app.NewService(nil, nil, nil, nil, slog.Default(), constants.AWS)
+		svc := app.NewService(nil, nil, nil, nil, nil, slog.Default(), constants.AWS)
 		router := &Router{svc: svc}
 		middleware := router.requestIDMiddleware(lambdaHandler)
 		middleware.ServeHTTP(rr, req)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -54,6 +54,11 @@ func NewRouter(svc *app.Service, requestTimeout time.Duration) *Router {
 			r.Post("/create", router.handleCreateUser)
 			r.Post("/revoke", router.handleRevokeUser)
 		})
+		r.With(router.authenticateRequestMiddleware).Route("/admin", func(r chi.Router) {
+			r.Route("/images", func(r chi.Router) {
+				r.Post("/register", router.handleRegisterImage)
+			})
+		})
 		r.With(router.authenticateRequestMiddleware).Post("/run", router.handleRunCommand)
 		r.With(router.authenticateRequestMiddleware).Get("/executions", router.handleListExecutions)
 		r.With(router.authenticateRequestMiddleware).Get("/executions/{executionID}/logs",


### PR DESCRIPTION
Propose a design for runtime ECS task definition registration to enable dynamic Docker images for the `/run` endpoint.

---
<a href="https://cursor.com/background-agent?bcId=bc-125f6341-b488-4ee3-b739-8c64499e5b3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-125f6341-b488-4ee3-b739-8c64499e5b3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

