### PR TITLE
Refactor: Separate business logic from infrastructure in app layer

### DIFF
--- a/internal/server/handlers_status_test.go
+++ b/internal/server/handlers_status_test.go
@@ -41,6 +41,10 @@ func (m *mockRunner) RemoveImage(ctx context.Context, image string) error {
 	return nil
 }
 
+func (m *mockRunner) FetchLogsByExecutionID(ctx context.Context, executionID string) ([]api.LogEvent, error) {
+	return []api.LogEvent{}, nil
+}
+
 // Test that the status endpoint exists and requires authentication
 func TestGetExecutionStatus_Unauthorized(t *testing.T) {
 	// Initialize a basic logger


### PR DESCRIPTION
## Summary

This PR refactors the  Service layer to properly separate business logic from infrastructure concerns by removing unnecessary type assertions and improving interface abstraction.

## Problem

The Service layer had several violations of the Dependency Inversion Principle:

1. **Type assertions to concrete infrastructure types** - Business logic was checking for specific DynamoDB repository implementation
2. **AWS-specific logic in service layer** - GetLogsByExecutionID was doing provider detection and type assertions
3. **Tight coupling** - Made testing difficult and prevented alternative implementations

## Changes

### 1. Removed DynamoDB Type Assertions in `CreateUser`

**Before:**
```go
userRepoDynamo, ok := s.userRepo.(*dynamorepo.UserRepository)
if \!ok {
    return nil, apperrors.ErrInternalError("user repository type assertion failed", nil)
}
if err := userRepoDynamo.CreateUserWithExpiration(ctx, user, apiKeyHash, expiresAt); err \!= nil {
    return nil, apperrors.ErrDatabaseError("failed to create user", err)
}
```

**After:**
```go
if err := s.userRepo.CreateUserWithExpiration(ctx, user, apiKeyHash, expiresAt); err \!= nil {
    return nil, apperrors.ErrDatabaseError("failed to create user", err)
}
```

**Why:** The methods `CreateUserWithExpiration` and `RemoveExpiration` are already part of the `UserRepository` interface, making the type assertion unnecessary.

### 2. Removed DynamoDB Type Assertions in `ClaimAPIKey`

Simplified from:
- 14 lines with type checking and error handling
- Defensive logging if type assertion fails

To:
- 4 lines calling interface method directly
- Cleaner error handling

### 3. Added `FetchLogsByExecutionID` to `Runner` Interface

**Before:** Method only existed on AWS runner implementation  
**After:** Part of the Runner interface contract

```go
type Runner interface {
    // ... existing methods ...
    
    // FetchLogsByExecutionID retrieves logs for a specific execution.
    // Returns empty slice if logs are not available or not supported by the provider.
    FetchLogsByExecutionID(ctx context.Context, executionID string) ([]api.LogEvent, error)
}
```

### 4. Simplified `GetLogsByExecutionID` Implementation

**Before (23 lines):**
- Switch statement on provider
- Helper method with AWS type assertion
- Provider-specific error handling

**After (9 lines):**
- Direct call to `runner.FetchLogsByExecutionID()`
- Provider-agnostic implementation
- No type assertions needed

### 5. Cleanup
- Removed unused `dynamorepo` import
- Removed unused `appaws` import  
- Updated test mocks to implement new interface method

## Impact

### Code Quality
- ✅ Properly follows Dependency Inversion Principle
- ✅ Service layer no longer knows about concrete infrastructure types
- ✅ Eliminates 18 lines of unnecessary code
- ✅ Removes 3 type assertions (sources of bugs)

### Testability
- ✅ Much easier to test with mocks (no type assertions to work around)
- ✅ Enables alternative repository implementations without code changes
- ✅ Cleaner test setup

### Maintainability
- ✅ Clearer separation of concerns
- ✅ Less coupling between layers
- ✅ Easier to understand and modify

## Testing

- ✅ All existing tests pass
- ✅ No behavioral changes
- ✅ Pure refactoring - same functionality, better structure

## Files Changed

```
internal/app/main.go                     | -18 lines of infrastructure coupling
internal/server/handlers_status_test.go  | +4 lines for interface compliance
```

## Next Steps

This refactoring makes the codebase ready for:
1. Comprehensive unit testing of the app layer (no infrastructure dependencies)
2. Alternative repository implementations (PostgreSQL, in-memory, etc.)
3. Additional execution providers beyond AWS

## Related

This addresses the "Mixed Concerns" issue identified in PR #98's testing discussion.