### PR TITLE
Fix indent-error-flow revive warning

### DIFF
--- a/internal/app/aws/taskdef.go
+++ b/internal/app/aws/taskdef.go
@@ -565,13 +565,13 @@ func DeregisterTaskDefinitionsForImage(
 					"error":  err.Error(),
 				})
 				return fmt.Errorf("failed to deregister task definition revision: %w", err)
-			} else {
-				logger.Info("deregistered task definition revision", "context", map[string]string{
-					"family": family,
-					"image":  image,
-					"arn":    taskDefARN,
-				})
 			}
+
+			logger.Info("deregistered task definition revision", "context", map[string]string{
+				"family": family,
+				"image":  image,
+				"arn":    taskDefARN,
+			})
 		}
 
 		if listOutput.NextToken == nil {


### PR DESCRIPTION
This PR fixes the `indent-error-flow` revive linter warning by removing an unnecessary `else` block after a `return` statement.

## Problem

The linter flagged this pattern in `internal/app/aws/taskdef.go:568`:
```go
if err != nil {
    logger.Error(...)
    return fmt.Errorf(...)
} else {
    logger.Info(...)
}
```

When an `if` block ends with a `return`, the `else` is unnecessary and adds extra nesting.

## Solution

Removed the `else` block and outdented the success-path logging:
```go
if err != nil {
    logger.Error(...)
    return fmt.Errorf(...)
}

logger.Info(...)
```

## Benefits

- ✅ Fixes revive `indent-error-flow` warning
- ✅ Reduces nesting depth
- ✅ Follows idiomatic Go "happy path" pattern (handle errors first, continue with success)
- ✅ More readable code

## Impact

- **Behavioral change:** None - this is purely a stylistic refactoring
- **Revive errors:** 2 → 1 (only `unexported-return` in logger/context.go remains)
- **Tests:** All existing tests pass

## Related

- Addresses one of the last 2 revive errors identified in #110
- Contributes to #60 (code quality improvements)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>