### PR TITLE
Disable linter checks for cmd/runvoy

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -93,7 +93,7 @@ issues:
     - path: cmd/
       linters:
         - mnd
-    - path: cmd/runvoy
+    - path: cmd/runvoy/
       linters:
         - gochecknoinits
     - text: "Error return value of .((os\\.)?std(out|err)\\..*|.*Close|.*Flush|os\\.Remove(All)?|.*printf?|os\\.(Un)?Setenv). is not checked"


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-13c5e444-d18f-418e-af85-aeea7b7df396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-13c5e444-d18f-418e-af85-aeea7b7df396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

