### PR TITLE
refactor: implement service pattern for CLI commands

### DIFF
--- a/cmd/runvoy/cmd/claim.go
+++ b/cmd/runvoy/cmd/claim.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"runvoy/internal/client"
@@ -33,18 +34,59 @@ func runClaim(cmd *cobra.Command, args []string) {
 	}
 
 	c := client.New(cfg, slog.Default())
-	resp, err := c.ClaimAPIKey(cmd.Context(), token)
-	if err != nil {
+	service := NewClaimService(c, NewOutputWrapper(), NewConfigSaver())
+	if err := service.ClaimAPIKey(cmd.Context(), token, cfg); err != nil {
 		output.Errorf(err.Error())
-		return
+	}
+}
+
+// ConfigSaver defines an interface for saving configuration
+type ConfigSaver interface {
+	Save(config *config.Config) error
+}
+
+// configSaverWrapper wraps the global config.Save function to implement ConfigSaver
+type configSaverWrapper struct{}
+
+func (c *configSaverWrapper) Save(cfg *config.Config) error {
+	return config.Save(cfg)
+}
+
+// NewConfigSaver creates a new ConfigSaver that uses the global config.Save function
+func NewConfigSaver() ConfigSaver {
+	return &configSaverWrapper{}
+}
+
+// ClaimService handles API key claiming logic
+type ClaimService struct {
+	client     client.Interface
+	output     OutputInterface
+	configSaver ConfigSaver
+}
+
+// NewClaimService creates a new ClaimService with the provided dependencies
+func NewClaimService(client client.Interface, output OutputInterface, configSaver ConfigSaver) *ClaimService {
+	return &ClaimService{
+		client:     client,
+		output:     output,
+		configSaver: configSaver,
+	}
+}
+
+// ClaimAPIKey claims an API key using the provided token and saves it to the config
+func (s *ClaimService) ClaimAPIKey(ctx context.Context, token string, cfg *config.Config) error {
+	resp, err := s.client.ClaimAPIKey(ctx, token)
+	if err != nil {
+		return fmt.Errorf("failed to claim API key: %w", err)
 	}
 
 	cfg.APIKey = resp.APIKey
-	if err = config.Save(cfg); err != nil {
-		output.Errorf("failed to save API key to config: %v", err)
-		output.Warningf("API Key => %s", output.Bold(resp.APIKey))
-		return
+	if err = s.configSaver.Save(cfg); err != nil {
+		s.output.Errorf("failed to save API key to config: %v", err)
+		s.output.Warningf("API Key => %s", s.output.Bold(resp.APIKey))
+		return fmt.Errorf("failed to save API key to config: %w", err)
 	}
 
-	output.Successf("API key claimed successfully and saved to config")
+	s.output.Successf("API key claimed successfully and saved to config")
+	return nil
 }

--- a/cmd/runvoy/cmd/claim_test.go
+++ b/cmd/runvoy/cmd/claim_test.go
@@ -1,0 +1,229 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"runvoy/internal/api"
+	"runvoy/internal/config"
+)
+
+// mockClientInterfaceForClaim extends mockClientInterface with ClaimAPIKey
+type mockClientInterfaceForClaim struct {
+	*mockClientInterface
+	claimAPIKeyFunc func(ctx context.Context, token string) (*api.ClaimAPIKeyResponse, error)
+}
+
+func (m *mockClientInterfaceForClaim) ClaimAPIKey(ctx context.Context, token string) (*api.ClaimAPIKeyResponse, error) {
+	if m.claimAPIKeyFunc != nil {
+		return m.claimAPIKeyFunc(ctx, token)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+
+// mockConfigSaver is a mock for ConfigSaver interface
+type mockConfigSaver struct {
+	saveFunc func(cfg *config.Config) error
+}
+
+func (m *mockConfigSaver) Save(cfg *config.Config) error {
+	if m.saveFunc != nil {
+		return m.saveFunc(cfg)
+	}
+	return nil
+}
+
+func TestClaimService_ClaimAPIKey(t *testing.T) {
+	tests := []struct {
+		name         string
+		token        string
+		cfg          *config.Config
+		setupClient  func(*mockClientInterfaceForClaim)
+		setupSaver   func(*mockConfigSaver)
+		wantErr      bool
+		verifyOutput func(*testing.T, *mockOutputInterface)
+		verifyConfig func(*testing.T, *config.Config)
+	}{
+		{
+			name:  "successfully claims API key and saves to config",
+			token:  "valid-token-123",
+			cfg:    &config.Config{APIEndpoint: "https://api.example.com"},
+			setupClient: func(m *mockClientInterfaceForClaim) {
+				m.claimAPIKeyFunc = func(ctx context.Context, token string) (*api.ClaimAPIKeyResponse, error) {
+					assert.Equal(t, "valid-token-123", token)
+					return &api.ClaimAPIKeyResponse{
+						APIKey:    "sk_live_abc123",
+						UserEmail: "user@example.com",
+					}, nil
+				}
+			},
+			setupSaver: func(m *mockConfigSaver) {
+				m.saveFunc = func(cfg *config.Config) error {
+					assert.Equal(t, "sk_live_abc123", cfg.APIKey)
+					return nil
+				}
+			},
+			wantErr: false,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				hasSuccess := false
+				for _, call := range m.calls {
+					if call.method == "Successf" {
+						hasSuccess = true
+						break
+					}
+				}
+				assert.True(t, hasSuccess, "Expected Successf call")
+			},
+			verifyConfig: func(t *testing.T, cfg *config.Config) {
+				assert.Equal(t, "sk_live_abc123", cfg.APIKey)
+			},
+		},
+		{
+			name:  "handles invalid token",
+			token:  "invalid-token",
+			cfg:    &config.Config{APIEndpoint: "https://api.example.com"},
+			setupClient: func(m *mockClientInterfaceForClaim) {
+				m.claimAPIKeyFunc = func(ctx context.Context, token string) (*api.ClaimAPIKeyResponse, error) {
+					return nil, fmt.Errorf("invalid token")
+				}
+			},
+			setupSaver: func(m *mockConfigSaver) {},
+			wantErr:    true,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				// Should not have Successf call when there's an error
+				for _, call := range m.calls {
+					assert.NotEqual(t, "Successf", call.method, "Should not display success on error")
+				}
+			},
+			verifyConfig: func(t *testing.T, cfg *config.Config) {
+				// APIKey should not be set on error
+				assert.Empty(t, cfg.APIKey)
+			},
+		},
+		{
+			name:  "handles network error",
+			token:  "network-token",
+			cfg:    &config.Config{APIEndpoint: "https://api.example.com"},
+			setupClient: func(m *mockClientInterfaceForClaim) {
+				m.claimAPIKeyFunc = func(ctx context.Context, token string) (*api.ClaimAPIKeyResponse, error) {
+					return nil, fmt.Errorf("network error: connection refused")
+				}
+			},
+			setupSaver: func(m *mockConfigSaver) {},
+			wantErr:    true,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				// Service returns error, output.Errorf is called in runClaim handler
+				// So no output calls should be made in the service itself
+				assert.Equal(t, 0, len(m.calls), "Service should not call output on network error")
+			},
+			verifyConfig: func(t *testing.T, cfg *config.Config) {
+				assert.Empty(t, cfg.APIKey)
+			},
+		},
+		{
+			name:  "handles config save failure",
+			token:  "valid-token",
+			cfg:    &config.Config{APIEndpoint: "https://api.example.com"},
+			setupClient: func(m *mockClientInterfaceForClaim) {
+				m.claimAPIKeyFunc = func(ctx context.Context, token string) (*api.ClaimAPIKeyResponse, error) {
+					return &api.ClaimAPIKeyResponse{
+						APIKey:    "sk_live_xyz789",
+						UserEmail: "user@example.com",
+					}, nil
+				}
+			},
+			setupSaver: func(m *mockConfigSaver) {
+				m.saveFunc = func(cfg *config.Config) error {
+					return fmt.Errorf("failed to write config file: permission denied")
+				}
+			},
+			wantErr: true,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				hasError := false
+				hasWarning := false
+				for _, call := range m.calls {
+					if call.method == "Errorf" {
+						hasError = true
+					}
+					if call.method == "Warningf" {
+						hasWarning = true
+					}
+				}
+				assert.True(t, hasError, "Expected Errorf call on save failure")
+				assert.True(t, hasWarning, "Expected Warningf call with API key when save fails")
+			},
+			verifyConfig: func(t *testing.T, cfg *config.Config) {
+				// APIKey should still be set even if save fails
+				assert.Equal(t, "sk_live_xyz789", cfg.APIKey)
+			},
+		},
+		{
+			name:  "displays warning with API key when save fails",
+			token:  "token-456",
+			cfg:    &config.Config{APIEndpoint: "https://api.example.com"},
+			setupClient: func(m *mockClientInterfaceForClaim) {
+				m.claimAPIKeyFunc = func(ctx context.Context, token string) (*api.ClaimAPIKeyResponse, error) {
+					return &api.ClaimAPIKeyResponse{
+						APIKey: "sk_live_warning123",
+					}, nil
+				}
+			},
+			setupSaver: func(m *mockConfigSaver) {
+				m.saveFunc = func(cfg *config.Config) error {
+					return fmt.Errorf("save error")
+				}
+			},
+			wantErr: true,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				hasWarningWithAPIKey := false
+				for _, call := range m.calls {
+					if call.method == "Warningf" && len(call.args) >= 1 {
+						format := call.args[0].(string)
+						if fmt.Sprintf(format, call.args[1:]...) != "" {
+							hasWarningWithAPIKey = true
+						}
+					}
+				}
+				assert.True(t, hasWarningWithAPIKey, "Expected warning with API key")
+			},
+			verifyConfig: func(t *testing.T, cfg *config.Config) {
+				assert.Equal(t, "sk_live_warning123", cfg.APIKey)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockClientInterfaceForClaim{
+				mockClientInterface: &mockClientInterface{},
+			}
+			tt.setupClient(mockClient)
+
+			mockSaver := &mockConfigSaver{}
+			tt.setupSaver(mockSaver)
+
+			mockOutput := &mockOutputInterface{}
+			service := NewClaimService(mockClient, mockOutput, mockSaver)
+
+			err := service.ClaimAPIKey(context.Background(), tt.token, tt.cfg)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if tt.verifyOutput != nil {
+				tt.verifyOutput(t, mockOutput)
+			}
+
+			if tt.verifyConfig != nil {
+				tt.verifyConfig(t, tt.cfg)
+			}
+		})
+	}
+}
+

--- a/cmd/runvoy/cmd/configure_test.go
+++ b/cmd/runvoy/cmd/configure_test.go
@@ -1,0 +1,281 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"runvoy/internal/config"
+)
+
+// mockOutputInterfaceWithPrompt extends mockOutputInterface with configurable Prompt behavior
+type mockOutputInterfaceWithPrompt struct {
+	*mockOutputInterface
+	promptFunc func(prompt string) string
+}
+
+func (m *mockOutputInterfaceWithPrompt) Prompt(prompt string) string {
+	m.calls = append(m.calls, call{method: "Prompt", args: []interface{}{prompt}})
+	if m.promptFunc != nil {
+		return m.promptFunc(prompt)
+	}
+	return ""
+}
+
+// mockConfigLoader is a mock for ConfigLoader interface
+type mockConfigLoader struct {
+	loadFunc func() (*config.Config, error)
+}
+
+func (m *mockConfigLoader) Load() (*config.Config, error) {
+	if m.loadFunc != nil {
+		return m.loadFunc()
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+
+func TestConfigureService_Configure(t *testing.T) {
+	tests := []struct {
+		name              string
+		setupPrompt       func(*mockOutputInterfaceWithPrompt)
+		setupLoader       func(*mockConfigLoader)
+		setupSaver        func(*mockConfigSaver)
+		setupPathGetter   func() (string, error)
+		wantErr           bool
+		verifyOutput      func(*testing.T, *mockOutputInterfaceWithPrompt)
+	}{
+		{
+			name: "successfully creates new configuration",
+			setupPrompt: func(m *mockOutputInterfaceWithPrompt) {
+				m.promptFunc = func(prompt string) string {
+					if prompt == "Enter API endpoint URL" {
+						return "https://api.example.com"
+					}
+					if prompt == "Enter API key" {
+						return "sk_live_abc123"
+					}
+					return ""
+				}
+			},
+			setupLoader: func(m *mockConfigLoader) {
+				m.loadFunc = func() (*config.Config, error) {
+					return nil, fmt.Errorf("config not found")
+				}
+			},
+			setupSaver: func(m *mockConfigSaver) {
+				m.saveFunc = func(cfg *config.Config) error {
+					assert.Equal(t, "https://api.example.com", cfg.APIEndpoint)
+					assert.Equal(t, "sk_live_abc123", cfg.APIKey)
+					return nil
+				}
+			},
+			setupPathGetter: func() (string, error) {
+				return "/home/user/.runvoy/config.yaml", nil
+			},
+			wantErr: false,
+			verifyOutput: func(t *testing.T, m *mockOutputInterfaceWithPrompt) {
+				hasInfof := false
+				hasSuccess := false
+				hasKeyValue := false
+				for _, call := range m.calls {
+					if call.method == "Infof" {
+						hasInfof = true
+					}
+					if call.method == "Successf" {
+						hasSuccess = true
+					}
+					if call.method == "KeyValue" && len(call.args) >= 2 {
+						if call.args[0] == "Configuration path" {
+							hasKeyValue = true
+						}
+					}
+				}
+				assert.True(t, hasInfof, "Expected Infof call")
+				assert.True(t, hasSuccess, "Expected Successf call")
+				assert.True(t, hasKeyValue, "Expected KeyValue call")
+			},
+		},
+		{
+			name: "updates existing configuration with new values",
+			setupPrompt: func(m *mockOutputInterfaceWithPrompt) {
+				m.promptFunc = func(prompt string) string {
+					if prompt == "Enter API endpoint URL" {
+						return "https://api.new.com"
+					}
+					if prompt == "Enter API key" {
+						return "sk_live_newkey"
+					}
+					return ""
+				}
+			},
+			setupLoader: func(m *mockConfigLoader) {
+				m.loadFunc = func() (*config.Config, error) {
+					return &config.Config{
+						APIEndpoint: "https://api.old.com",
+						APIKey:      "sk_live_oldkey",
+					}, nil
+				}
+			},
+			setupSaver: func(m *mockConfigSaver) {
+				m.saveFunc = func(cfg *config.Config) error {
+					assert.Equal(t, "https://api.new.com", cfg.APIEndpoint)
+					assert.Equal(t, "sk_live_newkey", cfg.APIKey)
+					return nil
+				}
+			},
+			setupPathGetter: func() (string, error) {
+				return "/home/user/.runvoy/config.yaml", nil
+			},
+			wantErr: false,
+			verifyOutput: func(t *testing.T, m *mockOutputInterfaceWithPrompt) {
+				hasSuccess := false
+				for _, call := range m.calls {
+					if call.method == "Successf" {
+						hasSuccess = true
+					}
+				}
+				assert.True(t, hasSuccess, "Expected Successf call")
+			},
+		},
+		{
+			name: "uses existing values when prompt returns empty",
+			setupPrompt: func(m *mockOutputInterfaceWithPrompt) {
+				m.promptFunc = func(prompt string) string {
+					return "" // User presses Enter without typing
+				}
+			},
+			setupLoader: func(m *mockConfigLoader) {
+				m.loadFunc = func() (*config.Config, error) {
+					return &config.Config{
+						APIEndpoint: "https://api.existing.com",
+						APIKey:      "sk_live_existing",
+					}, nil
+				}
+			},
+			setupSaver: func(m *mockConfigSaver) {
+				m.saveFunc = func(cfg *config.Config) error {
+					assert.Equal(t, "https://api.existing.com", cfg.APIEndpoint)
+					assert.Equal(t, "sk_live_existing", cfg.APIKey)
+					return nil
+				}
+			},
+			setupPathGetter: func() (string, error) {
+				return "/home/user/.runvoy/config.yaml", nil
+			},
+			wantErr: false,
+			verifyOutput: func(t *testing.T, m *mockOutputInterfaceWithPrompt) {
+				hasInfof := false
+				for _, call := range m.calls {
+					if call.method == "Infof" {
+						format := call.args[0].(string)
+						if format == "Using existing endpoint: %s" || format == "Using existing API key" {
+							hasInfof = true
+						}
+					}
+				}
+				assert.True(t, hasInfof, "Expected Infof call for using existing values")
+			},
+		},
+		{
+			name: "returns error when endpoint is required but not provided",
+			setupPrompt: func(m *mockOutputInterfaceWithPrompt) {
+				m.promptFunc = func(prompt string) string {
+					return "" // Empty response
+				}
+			},
+			setupLoader: func(m *mockConfigLoader) {
+				m.loadFunc = func() (*config.Config, error) {
+					return nil, fmt.Errorf("config not found")
+				}
+			},
+			setupSaver: func(m *mockConfigSaver) {},
+			setupPathGetter: func() (string, error) {
+				return "", nil
+			},
+			wantErr: true,
+			verifyOutput: func(t *testing.T, m *mockOutputInterfaceWithPrompt) {
+				hasSuccess := false
+				for _, call := range m.calls {
+					if call.method == "Successf" {
+						hasSuccess = true
+					}
+				}
+				assert.False(t, hasSuccess, "Should not have Successf on error")
+			},
+		},
+		{
+			name: "returns error when config save fails",
+			setupPrompt: func(m *mockOutputInterfaceWithPrompt) {
+				m.promptFunc = func(prompt string) string {
+					if prompt == "Enter API endpoint URL" {
+						return "https://api.example.com"
+					}
+					if prompt == "Enter API key" {
+						return "sk_live_abc123"
+					}
+					return ""
+				}
+			},
+			setupLoader: func(m *mockConfigLoader) {
+				m.loadFunc = func() (*config.Config, error) {
+					return nil, fmt.Errorf("config not found")
+				}
+			},
+			setupSaver: func(m *mockConfigSaver) {
+				m.saveFunc = func(cfg *config.Config) error {
+					return fmt.Errorf("permission denied")
+				}
+			},
+			setupPathGetter: func() (string, error) {
+				return "", nil
+			},
+			wantErr: true,
+			verifyOutput: func(t *testing.T, m *mockOutputInterfaceWithPrompt) {
+				hasSuccess := false
+				for _, call := range m.calls {
+					if call.method == "Successf" {
+						hasSuccess = true
+					}
+				}
+				assert.False(t, hasSuccess, "Should not have Successf on error")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockOutput := &mockOutputInterfaceWithPrompt{
+				mockOutputInterface: &mockOutputInterface{},
+			}
+			tt.setupPrompt(mockOutput)
+
+			mockLoader := &mockConfigLoader{}
+			tt.setupLoader(mockLoader)
+
+			mockSaver := &mockConfigSaver{}
+			tt.setupSaver(mockSaver)
+
+			service := NewConfigureService(
+				mockOutput,
+				mockSaver,
+				mockLoader.Load,
+				tt.setupPathGetter,
+			)
+
+			err := service.Configure(context.Background())
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if tt.verifyOutput != nil {
+				tt.verifyOutput(t, mockOutput)
+			}
+		})
+	}
+}
+

--- a/cmd/runvoy/cmd/images.go
+++ b/cmd/runvoy/cmd/images.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
+	"runvoy/internal/api"
 	"runvoy/internal/client"
 	"runvoy/internal/constants"
 	"runvoy/internal/output"
@@ -65,20 +67,15 @@ func registerImageRun(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	c := client.New(cfg, slog.Default())
 	var isDefault *bool
 	if cmd.Flags().Changed("set-default") {
 		isDefault = &registerImageIsDefault
 	}
-	resp, err := c.RegisterImage(cmd.Context(), image, isDefault)
-	if err != nil {
-		output.Errorf("failed to register image: %v", err)
-		return
-	}
-	output.Successf("Image registered successfully")
-	output.KeyValue("Image", resp.Image)
-	if resp.Message != "" {
-		output.KeyValue("Message", resp.Message)
+
+	c := client.New(cfg, slog.Default())
+	service := NewImagesService(c, NewOutputWrapper())
+	if err := service.RegisterImage(cmd.Context(), image, isDefault); err != nil {
+		output.Errorf(err.Error())
 	}
 }
 
@@ -90,30 +87,10 @@ func listImagesRun(cmd *cobra.Command, _ []string) {
 	}
 
 	c := client.New(cfg, slog.Default())
-	resp, err := c.ListImages(cmd.Context())
-	if err != nil {
-		output.Errorf("failed to list images: %v", err)
-		return
+	service := NewImagesService(c, NewOutputWrapper())
+	if err := service.ListImages(cmd.Context()); err != nil {
+		output.Errorf(err.Error())
 	}
-
-	rows := make([][]string, 0, len(resp.Images))
-	for _, image := range resp.Images {
-		rows = append(rows, []string{
-			image.Image,
-			strconv.FormatBool(*image.IsDefault),
-		})
-	}
-
-	output.Blank()
-	output.Table(
-		[]string{
-			"Image",
-			"Is Default",
-		},
-		rows,
-	)
-	output.Blank()
-	output.Successf("Images listed successfully")
 }
 
 func unregisterImageRun(cmd *cobra.Command, args []string) {
@@ -125,12 +102,84 @@ func unregisterImageRun(cmd *cobra.Command, args []string) {
 	}
 
 	c := client.New(cfg, slog.Default())
-	resp, err := c.UnregisterImage(cmd.Context(), image)
-	if err != nil {
-		output.Errorf("failed to remove image: %v", err)
-		return
+	service := NewImagesService(c, NewOutputWrapper())
+	if err := service.UnregisterImage(cmd.Context(), image); err != nil {
+		output.Errorf(err.Error())
 	}
-	output.Successf("Image removed successfully")
-	output.KeyValue("Image", resp.Image)
-	output.KeyValue("Message", resp.Message)
+}
+
+// ImagesService handles image management logic
+type ImagesService struct {
+	client client.Interface
+	output OutputInterface
+}
+
+// NewImagesService creates a new ImagesService with the provided dependencies
+func NewImagesService(client client.Interface, output OutputInterface) *ImagesService {
+	return &ImagesService{
+		client: client,
+		output: output,
+	}
+}
+
+// RegisterImage registers a new image
+func (s *ImagesService) RegisterImage(ctx context.Context, image string, isDefault *bool) error {
+	resp, err := s.client.RegisterImage(ctx, image, isDefault)
+	if err != nil {
+		return fmt.Errorf("failed to register image: %w", err)
+	}
+
+	s.output.Successf("Image registered successfully")
+	s.output.KeyValue("Image", resp.Image)
+	if resp.Message != "" {
+		s.output.KeyValue("Message", resp.Message)
+	}
+	return nil
+}
+
+// ListImages lists all registered images
+func (s *ImagesService) ListImages(ctx context.Context) error {
+	resp, err := s.client.ListImages(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list images: %w", err)
+	}
+
+	rows := s.formatImages(resp.Images)
+
+	s.output.Blank()
+	s.output.Table(
+		[]string{
+			"Image",
+			"Is Default",
+		},
+		rows,
+	)
+	s.output.Blank()
+	s.output.Successf("Images listed successfully")
+	return nil
+}
+
+// UnregisterImage unregisters an image
+func (s *ImagesService) UnregisterImage(ctx context.Context, image string) error {
+	resp, err := s.client.UnregisterImage(ctx, image)
+	if err != nil {
+		return fmt.Errorf("failed to remove image: %w", err)
+	}
+
+	s.output.Successf("Image removed successfully")
+	s.output.KeyValue("Image", resp.Image)
+	s.output.KeyValue("Message", resp.Message)
+	return nil
+}
+
+// formatImages formats image data into table rows
+func (s *ImagesService) formatImages(images []api.ImageInfo) [][]string {
+	rows := make([][]string, 0, len(images))
+	for _, image := range images {
+		rows = append(rows, []string{
+			image.Image,
+			strconv.FormatBool(*image.IsDefault),
+		})
+	}
+	return rows
 }

--- a/cmd/runvoy/cmd/images_test.go
+++ b/cmd/runvoy/cmd/images_test.go
@@ -1,0 +1,357 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"runvoy/internal/api"
+)
+
+// mockClientInterfaceForImages extends mockClientInterface with image management methods
+type mockClientInterfaceForImages struct {
+	*mockClientInterface
+	registerImageFunc   func(ctx context.Context, image string, isDefault *bool) (*api.RegisterImageResponse, error)
+	listImagesFunc      func(ctx context.Context) (*api.ListImagesResponse, error)
+	unregisterImageFunc func(ctx context.Context, image string) (*api.RemoveImageResponse, error)
+}
+
+func (m *mockClientInterfaceForImages) RegisterImage(ctx context.Context, image string, isDefault *bool) (*api.RegisterImageResponse, error) {
+	if m.registerImageFunc != nil {
+		return m.registerImageFunc(ctx, image, isDefault)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockClientInterfaceForImages) ListImages(ctx context.Context) (*api.ListImagesResponse, error) {
+	if m.listImagesFunc != nil {
+		return m.listImagesFunc(ctx)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockClientInterfaceForImages) UnregisterImage(ctx context.Context, image string) (*api.RemoveImageResponse, error) {
+	if m.unregisterImageFunc != nil {
+		return m.unregisterImageFunc(ctx, image)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+
+func TestImagesService_RegisterImage(t *testing.T) {
+	tests := []struct {
+		name         string
+		image        string
+		isDefault    *bool
+		setupMock    func(*mockClientInterfaceForImages)
+		wantErr      bool
+		verifyOutput func(*testing.T, *mockOutputInterface)
+	}{
+		{
+			name:     "successfully registers image",
+			image:    "alpine:latest",
+			isDefault: nil,
+			setupMock: func(m *mockClientInterfaceForImages) {
+				m.registerImageFunc = func(ctx context.Context, image string, isDefault *bool) (*api.RegisterImageResponse, error) {
+					assert.Equal(t, "alpine:latest", image)
+					assert.Nil(t, isDefault)
+					return &api.RegisterImageResponse{
+						Image:   "alpine:latest",
+						Message: "Image registered",
+					}, nil
+				}
+			},
+			wantErr: false,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				hasSuccess := false
+				hasKeyValue := false
+				for _, call := range m.calls {
+					if call.method == "Successf" {
+						hasSuccess = true
+					}
+					if call.method == "KeyValue" && len(call.args) >= 2 {
+						if call.args[0] == "Image" {
+							hasKeyValue = true
+						}
+					}
+				}
+				assert.True(t, hasSuccess, "Expected Successf call")
+				assert.True(t, hasKeyValue, "Expected KeyValue call")
+			},
+		},
+		{
+			name:     "registers image as default",
+			image:    "ubuntu:22.04",
+			isDefault: func() *bool { b := true; return &b }(),
+			setupMock: func(m *mockClientInterfaceForImages) {
+				m.registerImageFunc = func(ctx context.Context, image string, isDefault *bool) (*api.RegisterImageResponse, error) {
+					assert.Equal(t, "ubuntu:22.04", image)
+					assert.NotNil(t, isDefault)
+					assert.True(t, *isDefault)
+					return &api.RegisterImageResponse{
+						Image:   "ubuntu:22.04",
+						Message: "Image registered as default",
+					}, nil
+				}
+			},
+			wantErr: false,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				hasMessage := false
+				for _, call := range m.calls {
+					if call.method == "KeyValue" && len(call.args) >= 2 {
+						if call.args[0] == "Message" {
+							hasMessage = true
+						}
+					}
+				}
+				assert.True(t, hasMessage, "Expected Message KeyValue call")
+			},
+		},
+		{
+			name:     "handles client error",
+			image:    "invalid:image",
+			isDefault: nil,
+			setupMock: func(m *mockClientInterfaceForImages) {
+				m.registerImageFunc = func(ctx context.Context, image string, isDefault *bool) (*api.RegisterImageResponse, error) {
+					return nil, fmt.Errorf("invalid image format")
+				}
+			},
+			wantErr: true,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				hasSuccess := false
+				for _, call := range m.calls {
+					if call.method == "Successf" {
+						hasSuccess = true
+					}
+				}
+				assert.False(t, hasSuccess, "Should not have Successf on error")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockClientInterfaceForImages{
+				mockClientInterface: &mockClientInterface{},
+			}
+			tt.setupMock(mockClient)
+
+			mockOutput := &mockOutputInterface{}
+			service := NewImagesService(mockClient, mockOutput)
+
+			err := service.RegisterImage(context.Background(), tt.image, tt.isDefault)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if tt.verifyOutput != nil {
+				tt.verifyOutput(t, mockOutput)
+			}
+		})
+	}
+}
+
+func TestImagesService_ListImages(t *testing.T) {
+	tests := []struct {
+		name         string
+		setupMock    func(*mockClientInterfaceForImages)
+		wantErr      bool
+		verifyOutput func(*testing.T, *mockOutputInterface)
+	}{
+		{
+			name: "successfully lists images",
+			setupMock: func(m *mockClientInterfaceForImages) {
+				m.listImagesFunc = func(ctx context.Context) (*api.ListImagesResponse, error) {
+					isDefaultTrue := true
+					isDefaultFalse := false
+					return &api.ListImagesResponse{
+						Images: []api.ImageInfo{
+							{
+								Image:     "alpine:latest",
+								IsDefault: &isDefaultTrue,
+							},
+							{
+								Image:     "ubuntu:22.04",
+								IsDefault: &isDefaultFalse,
+							},
+						},
+					}, nil
+				}
+			},
+			wantErr: false,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				hasTable := false
+				hasSuccess := false
+				for _, call := range m.calls {
+					if call.method == "Table" {
+						hasTable = true
+						if len(call.args) >= 2 {
+							rows := call.args[1].([][]string)
+							assert.Equal(t, 2, len(rows), "Should have 2 image rows")
+						}
+					}
+					if call.method == "Successf" {
+						hasSuccess = true
+					}
+				}
+				assert.True(t, hasTable, "Expected Table call")
+				assert.True(t, hasSuccess, "Expected Successf call")
+			},
+		},
+		{
+			name: "handles empty image list",
+			setupMock: func(m *mockClientInterfaceForImages) {
+				m.listImagesFunc = func(ctx context.Context) (*api.ListImagesResponse, error) {
+					return &api.ListImagesResponse{
+						Images: []api.ImageInfo{},
+					}, nil
+				}
+			},
+			wantErr: false,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				hasTable := false
+				for _, call := range m.calls {
+					if call.method == "Table" {
+						hasTable = true
+						if len(call.args) >= 2 {
+							rows := call.args[1].([][]string)
+							assert.Equal(t, 0, len(rows), "Should have empty rows")
+						}
+					}
+				}
+				assert.True(t, hasTable, "Expected Table call even with empty list")
+			},
+		},
+		{
+			name: "handles client error",
+			setupMock: func(m *mockClientInterfaceForImages) {
+				m.listImagesFunc = func(ctx context.Context) (*api.ListImagesResponse, error) {
+					return nil, fmt.Errorf("network error")
+				}
+			},
+			wantErr: true,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				hasTable := false
+				for _, call := range m.calls {
+					if call.method == "Table" {
+						hasTable = true
+					}
+				}
+				assert.False(t, hasTable, "Should not call Table on error")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockClientInterfaceForImages{
+				mockClientInterface: &mockClientInterface{},
+			}
+			tt.setupMock(mockClient)
+
+			mockOutput := &mockOutputInterface{}
+			service := NewImagesService(mockClient, mockOutput)
+
+			err := service.ListImages(context.Background())
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if tt.verifyOutput != nil {
+				tt.verifyOutput(t, mockOutput)
+			}
+		})
+	}
+}
+
+func TestImagesService_UnregisterImage(t *testing.T) {
+	tests := []struct {
+		name         string
+		image        string
+		setupMock    func(*mockClientInterfaceForImages)
+		wantErr      bool
+		verifyOutput func(*testing.T, *mockOutputInterface)
+	}{
+		{
+			name:  "successfully unregisters image",
+			image: "alpine:latest",
+			setupMock: func(m *mockClientInterfaceForImages) {
+				m.unregisterImageFunc = func(ctx context.Context, image string) (*api.RemoveImageResponse, error) {
+					assert.Equal(t, "alpine:latest", image)
+					return &api.RemoveImageResponse{
+						Image:   "alpine:latest",
+						Message: "Image removed successfully",
+					}, nil
+				}
+			},
+			wantErr: false,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				hasSuccess := false
+				hasKeyValue := false
+				for _, call := range m.calls {
+					if call.method == "Successf" {
+						hasSuccess = true
+					}
+					if call.method == "KeyValue" && len(call.args) >= 2 {
+						if call.args[0] == "Image" || call.args[0] == "Message" {
+							hasKeyValue = true
+						}
+					}
+				}
+				assert.True(t, hasSuccess, "Expected Successf call")
+				assert.True(t, hasKeyValue, "Expected KeyValue calls")
+			},
+		},
+		{
+			name:  "handles image not found error",
+			image: "nonexistent:latest",
+			setupMock: func(m *mockClientInterfaceForImages) {
+				m.unregisterImageFunc = func(ctx context.Context, image string) (*api.RemoveImageResponse, error) {
+					return nil, fmt.Errorf("image not found")
+				}
+			},
+			wantErr: true,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				hasSuccess := false
+				for _, call := range m.calls {
+					if call.method == "Successf" {
+						hasSuccess = true
+					}
+				}
+				assert.False(t, hasSuccess, "Should not have Successf on error")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockClientInterfaceForImages{
+				mockClientInterface: &mockClientInterface{},
+			}
+			tt.setupMock(mockClient)
+
+			mockOutput := &mockOutputInterface{}
+			service := NewImagesService(mockClient, mockOutput)
+
+			err := service.UnregisterImage(context.Background(), tt.image)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if tt.verifyOutput != nil {
+				tt.verifyOutput(t, mockOutput)
+			}
+		})
+	}
+}
+

--- a/cmd/runvoy/cmd/kill_test.go
+++ b/cmd/runvoy/cmd/kill_test.go
@@ -1,0 +1,167 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"runvoy/internal/api"
+)
+
+// mockClientInterfaceForKill extends mockClientInterface with KillExecution
+type mockClientInterfaceForKill struct {
+	*mockClientInterface
+	killExecutionFunc func(ctx context.Context, executionID string) (*api.KillExecutionResponse, error)
+}
+
+func (m *mockClientInterfaceForKill) KillExecution(ctx context.Context, executionID string) (*api.KillExecutionResponse, error) {
+	if m.killExecutionFunc != nil {
+		return m.killExecutionFunc(ctx, executionID)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+
+func TestKillService_KillExecution(t *testing.T) {
+	tests := []struct {
+		name         string
+		executionID  string
+		setupMock    func(*mockClientInterfaceForKill)
+		wantErr      bool
+		verifyOutput func(*testing.T, *mockOutputInterface)
+	}{
+		{
+			name:        "successfully kills execution",
+			executionID: "exec-123",
+			setupMock: func(m *mockClientInterfaceForKill) {
+				m.killExecutionFunc = func(ctx context.Context, executionID string) (*api.KillExecutionResponse, error) {
+					assert.Equal(t, "exec-123", executionID)
+					return &api.KillExecutionResponse{
+						ExecutionID: "exec-123",
+						Message:     "Execution terminated successfully",
+					}, nil
+				}
+			},
+			wantErr: false,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				hasSuccess := false
+				hasExecID := false
+				hasMessage := false
+				for _, call := range m.calls {
+					if call.method == "Successf" {
+						hasSuccess = true
+					}
+					if call.method == "KeyValue" && len(call.args) >= 2 {
+						if call.args[0] == "Execution ID" && call.args[1] == "exec-123" {
+							hasExecID = true
+						}
+						if call.args[0] == "Message" && call.args[1] == "Execution terminated successfully" {
+							hasMessage = true
+						}
+					}
+				}
+				assert.True(t, hasSuccess, "Expected Successf call")
+				assert.True(t, hasExecID, "Expected Execution ID to be displayed")
+				assert.True(t, hasMessage, "Expected Message to be displayed")
+			},
+		},
+		{
+			name:        "handles execution not found error",
+			executionID: "exec-nonexistent",
+			setupMock: func(m *mockClientInterfaceForKill) {
+				m.killExecutionFunc = func(ctx context.Context, executionID string) (*api.KillExecutionResponse, error) {
+					return nil, fmt.Errorf("execution not found")
+				}
+			},
+			wantErr: true,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				// Should not have Successf call when there's an error
+				for _, call := range m.calls {
+					assert.NotEqual(t, "Successf", call.method, "Should not display success on error")
+				}
+			},
+		},
+		{
+			name:        "handles network error",
+			executionID: "exec-456",
+			setupMock: func(m *mockClientInterfaceForKill) {
+				m.killExecutionFunc = func(ctx context.Context, executionID string) (*api.KillExecutionResponse, error) {
+					return nil, fmt.Errorf("network error: connection timeout")
+				}
+			},
+			wantErr: true,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				// Service returns error, output.Errorf is called in killRun handler
+				assert.Equal(t, 0, len(m.calls), "Service should not call output on error")
+			},
+		},
+		{
+			name:        "handles already completed execution",
+			executionID: "exec-completed",
+			setupMock: func(m *mockClientInterfaceForKill) {
+				m.killExecutionFunc = func(ctx context.Context, executionID string) (*api.KillExecutionResponse, error) {
+					return nil, fmt.Errorf("execution already completed")
+				}
+			},
+			wantErr: true,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				assert.Equal(t, 0, len(m.calls), "Service should not call output on error")
+			},
+		},
+		{
+			name:        "displays execution ID and message",
+			executionID: "exec-789",
+			setupMock: func(m *mockClientInterfaceForKill) {
+				m.killExecutionFunc = func(ctx context.Context, executionID string) (*api.KillExecutionResponse, error) {
+					return &api.KillExecutionResponse{
+						ExecutionID: "exec-789",
+						Message:     "Kill signal sent",
+					}, nil
+				}
+			},
+			wantErr: false,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				hasExecID := false
+				hasMessage := false
+				for _, call := range m.calls {
+					if call.method == "KeyValue" && len(call.args) >= 2 {
+						if call.args[0] == "Execution ID" {
+							hasExecID = true
+						}
+						if call.args[0] == "Message" {
+							hasMessage = true
+						}
+					}
+				}
+				assert.True(t, hasExecID, "Should display Execution ID")
+				assert.True(t, hasMessage, "Should display Message")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockClientInterfaceForKill{
+				mockClientInterface: &mockClientInterface{},
+			}
+			tt.setupMock(mockClient)
+
+			mockOutput := &mockOutputInterface{}
+			service := NewKillService(mockClient, mockOutput)
+
+			err := service.KillExecution(context.Background(), tt.executionID)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if tt.verifyOutput != nil {
+				tt.verifyOutput(t, mockOutput)
+			}
+		})
+	}
+}
+

--- a/cmd/runvoy/cmd/list_test.go
+++ b/cmd/runvoy/cmd/list_test.go
@@ -1,0 +1,247 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"runvoy/internal/api"
+)
+
+// mockClientInterfaceForList extends mockClientInterface with ListExecutions
+type mockClientInterfaceForList struct {
+	*mockClientInterface
+	listExecutionsFunc func(ctx context.Context) ([]api.Execution, error)
+}
+
+func (m *mockClientInterfaceForList) ListExecutions(ctx context.Context) ([]api.Execution, error) {
+	if m.listExecutionsFunc != nil {
+		return m.listExecutionsFunc(ctx)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+
+func TestListService_ListExecutions(t *testing.T) {
+	tests := []struct {
+		name         string
+		setupMock    func(*mockClientInterfaceForList)
+		wantErr      bool
+		verifyOutput func(*testing.T, *mockOutputInterface)
+	}{
+		{
+			name: "successfully lists executions",
+			setupMock: func(m *mockClientInterfaceForList) {
+				m.listExecutionsFunc = func(ctx context.Context) ([]api.Execution, error) {
+					now := time.Now()
+					return []api.Execution{
+						{
+							ExecutionID: "exec-1",
+							Status:      "completed",
+							Command:     "echo hello",
+							UserEmail:   "user@example.com",
+							StartedAt:   now,
+							CompletedAt: func() *time.Time { t := now.Add(5 * time.Second); return &t }(),
+							DurationSeconds: 5,
+						},
+					}, nil
+				}
+			},
+			wantErr: false,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				hasInfof := false
+				hasTable := false
+				hasSuccess := false
+				for _, call := range m.calls {
+					if call.method == "Infof" {
+						hasInfof = true
+					}
+					if call.method == "Table" {
+						hasTable = true
+						// Verify table headers
+						if len(call.args) >= 1 {
+							headers := call.args[0].([]string)
+							assert.Contains(t, headers, "Execution ID")
+							assert.Contains(t, headers, "Status")
+							assert.Contains(t, headers, "Command")
+						}
+					}
+					if call.method == "Successf" {
+						hasSuccess = true
+					}
+				}
+				assert.True(t, hasInfof, "Expected Infof call")
+				assert.True(t, hasTable, "Expected Table call")
+				assert.True(t, hasSuccess, "Expected Successf call")
+			},
+		},
+		{
+			name: "handles empty execution list",
+			setupMock: func(m *mockClientInterfaceForList) {
+				m.listExecutionsFunc = func(ctx context.Context) ([]api.Execution, error) {
+					return []api.Execution{}, nil
+				}
+			},
+			wantErr: false,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				hasTable := false
+				for _, call := range m.calls {
+					if call.method == "Table" {
+						hasTable = true
+						// Verify table is called with empty rows
+						if len(call.args) >= 2 {
+							rows := call.args[1].([][]string)
+							assert.Equal(t, 0, len(rows), "Should have empty rows")
+						}
+					}
+				}
+				assert.True(t, hasTable, "Expected Table call even with empty list")
+			},
+		},
+		{
+			name: "handles client error",
+			setupMock: func(m *mockClientInterfaceForList) {
+				m.listExecutionsFunc = func(ctx context.Context) ([]api.Execution, error) {
+					return nil, fmt.Errorf("network error")
+				}
+			},
+			wantErr: true,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				// Should have Infof call but not Table or Successf
+				hasInfof := false
+				hasTable := false
+				for _, call := range m.calls {
+					if call.method == "Infof" {
+						hasInfof = true
+					}
+					if call.method == "Table" {
+						hasTable = true
+					}
+				}
+				assert.True(t, hasInfof, "Expected Infof call")
+				assert.False(t, hasTable, "Should not call Table on error")
+			},
+		},
+		{
+			name: "formats long commands correctly",
+			setupMock: func(m *mockClientInterfaceForList) {
+				m.listExecutionsFunc = func(ctx context.Context) ([]api.Execution, error) {
+					longCommand := "this is a very long command that exceeds the maximum command length limit and should be truncated"
+					return []api.Execution{
+						{
+							ExecutionID: "exec-long",
+							Status:      "running",
+							Command:     longCommand,
+							UserEmail:   "user@example.com",
+							StartedAt:   time.Now(),
+						},
+					}, nil
+				}
+			},
+			wantErr: false,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				for _, call := range m.calls {
+					if call.method == "Table" && len(call.args) >= 2 {
+						rows := call.args[1].([][]string)
+						if len(rows) > 0 && len(rows[0]) > 2 {
+							command := rows[0][2] // Command column
+							assert.LessOrEqual(t, len(command), maxCommandLength+3, "Command should be truncated") // +3 for "..."
+							assert.Contains(t, command, "...", "Long command should end with ...")
+						}
+					}
+				}
+			},
+		},
+		{
+			name: "formats executions with completed and duration",
+			setupMock: func(m *mockClientInterfaceForList) {
+				m.listExecutionsFunc = func(ctx context.Context) ([]api.Execution, error) {
+					started := time.Now().Add(-10 * time.Minute)
+					completed := time.Now()
+					return []api.Execution{
+						{
+							ExecutionID:     "exec-completed",
+							Status:         "completed",
+							Command:        "test command",
+							UserEmail:      "user@example.com",
+							StartedAt:      started,
+							CompletedAt:    &completed,
+							DurationSeconds: 600,
+						},
+					}, nil
+				}
+			},
+			wantErr: false,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				for _, call := range m.calls {
+					if call.method == "Table" && len(call.args) >= 2 {
+						rows := call.args[1].([][]string)
+						if len(rows) > 0 && len(rows[0]) >= 7 {
+							completed := rows[0][5] // Completed (UTC) column
+							duration := rows[0][6]  // Duration column
+							assert.NotEmpty(t, completed, "Completed time should be set")
+							assert.NotEmpty(t, duration, "Duration should be set")
+							assert.Contains(t, duration, "s", "Duration should include seconds")
+						}
+					}
+				}
+			},
+		},
+		{
+			name: "formats executions without completed time",
+			setupMock: func(m *mockClientInterfaceForList) {
+				m.listExecutionsFunc = func(ctx context.Context) ([]api.Execution, error) {
+					return []api.Execution{
+						{
+							ExecutionID: "exec-running",
+							Status:      "running",
+							Command:     "running command",
+							UserEmail:   "user@example.com",
+							StartedAt:   time.Now(),
+							CompletedAt: nil,
+						},
+					}, nil
+				}
+			},
+			wantErr: false,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				for _, call := range m.calls {
+					if call.method == "Table" && len(call.args) >= 2 {
+						rows := call.args[1].([][]string)
+						if len(rows) > 0 && len(rows[0]) >= 6 {
+							completed := rows[0][5] // Completed (UTC) column
+							assert.Empty(t, completed, "Completed time should be empty for running execution")
+						}
+					}
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockClientInterfaceForList{
+				mockClientInterface: &mockClientInterface{},
+			}
+			tt.setupMock(mockClient)
+
+			mockOutput := &mockOutputInterface{}
+			service := NewListService(mockClient, mockOutput)
+
+			err := service.ListExecutions(context.Background())
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if tt.verifyOutput != nil {
+				tt.verifyOutput(t, mockOutput)
+			}
+		})
+	}
+}
+

--- a/cmd/runvoy/cmd/output_interface.go
+++ b/cmd/runvoy/cmd/output_interface.go
@@ -13,6 +13,7 @@ type OutputInterface interface {
 	Bold(text string) string
 	Cyan(text string) string
 	KeyValue(key, value string)
+	Prompt(prompt string) string
 }
 
 // outputWrapper wraps the global output package functions to implement OutputInterface
@@ -57,4 +58,8 @@ func (o *outputWrapper) Cyan(text string) string {
 
 func (o *outputWrapper) KeyValue(key, value string) {
 	output.KeyValue(key, value)
+}
+
+func (o *outputWrapper) Prompt(prompt string) string {
+	return output.Prompt(prompt)
 }

--- a/cmd/runvoy/cmd/status_test.go
+++ b/cmd/runvoy/cmd/status_test.go
@@ -96,6 +96,11 @@ func (m *mockOutputInterface) Cyan(text string) string {
 func (m *mockOutputInterface) KeyValue(key, value string) {
 	m.calls = append(m.calls, call{method: "KeyValue", args: []interface{}{key, value}})
 }
+func (m *mockOutputInterface) Prompt(prompt string) string {
+	m.calls = append(m.calls, call{method: "Prompt", args: []interface{}{prompt}})
+	// Return empty string by default - tests can override by checking calls
+	return ""
+}
 
 func TestStatusService_DisplayStatus(t *testing.T) {
 	tests := []struct {

--- a/cmd/runvoy/cmd/users.go
+++ b/cmd/runvoy/cmd/users.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"time"
@@ -35,55 +36,11 @@ func runListUsers(cmd *cobra.Command, _ []string) {
 		return
 	}
 
-	output.Infof("Listing users…")
-
 	c := client.New(cfg, slog.Default())
-	resp, err := c.ListUsers(cmd.Context())
-	if err != nil {
-		output.Errorf("failed to list users: %v", err)
-		return
+	service := NewUsersService(c, NewOutputWrapper())
+	if err := service.ListUsers(cmd.Context()); err != nil {
+		output.Errorf(err.Error())
 	}
-
-	if len(resp.Users) == 0 {
-		output.Blank()
-		output.Warningf("No users found")
-		return
-	}
-
-	rows := make([][]string, 0, len(resp.Users))
-	for _, u := range resp.Users {
-		createdAt := u.CreatedAt.UTC().Format(time.DateTime)
-
-		lastUsed := "Never"
-		if !u.LastUsed.IsZero() {
-			lastUsed = u.LastUsed.UTC().Format(time.DateTime)
-		}
-
-		status := "Active"
-		if u.Revoked {
-			status = "Revoked"
-		}
-
-		rows = append(rows, []string{
-			output.Bold(u.Email),
-			status,
-			createdAt,
-			lastUsed,
-		})
-	}
-
-	output.Blank()
-	output.Table(
-		[]string{
-			"Email",
-			"Status",
-			"Created (UTC)",
-			"Last Used (UTC)",
-		},
-		rows,
-	)
-	output.Blank()
-	output.Successf("Users listed successfully")
 }
 
 var revokeUserCmd = &cobra.Command{
@@ -100,19 +57,12 @@ func runRevokeUser(cmd *cobra.Command, args []string) {
 		return
 	}
 	email := args[0]
-	output.Infof("Revoking user with email %s...", email)
 
 	c := client.New(cfg, slog.Default())
-	resp, err := c.RevokeUser(cmd.Context(), api.RevokeUserRequest{
-		Email: email,
-	})
-	if err != nil {
+	service := NewUsersService(c, NewOutputWrapper())
+	if err := service.RevokeUser(cmd.Context(), email); err != nil {
 		output.Errorf(err.Error())
-		return
 	}
-
-	output.Successf("User revoked successfully")
-	output.KeyValue("Email", resp.Email)
 }
 
 func init() {
@@ -147,27 +97,123 @@ func runCreateUser(cmd *cobra.Command, args []string) {
 	}
 	email := args[0]
 
-	output.Infof("Creating user with email %s...", email)
-
 	c := client.New(cfg, slog.Default())
-	resp, err := c.CreateUser(cmd.Context(), api.CreateUserRequest{
+	service := NewUsersService(c, NewOutputWrapper())
+	if err := service.CreateUser(cmd.Context(), email); err != nil {
+		output.Errorf(err.Error())
+	}
+}
+
+// UsersService handles user management logic
+type UsersService struct {
+	client client.Interface
+	output OutputInterface
+}
+
+// NewUsersService creates a new UsersService with the provided dependencies
+func NewUsersService(client client.Interface, output OutputInterface) *UsersService {
+	return &UsersService{
+		client: client,
+		output: output,
+	}
+}
+
+// CreateUser creates a new user with the given email
+func (s *UsersService) CreateUser(ctx context.Context, email string) error {
+	s.output.Infof("Creating user with email %s...", email)
+
+	resp, err := s.client.CreateUser(ctx, api.CreateUserRequest{
 		Email: email,
 	})
 	if err != nil {
-		output.Errorf(err.Error())
-		return
+		return fmt.Errorf("failed to create user: %w", err)
 	}
 
-	output.Successf("User created successfully")
-	output.KeyValue("Email", resp.User.Email)
-	output.KeyValue("Claim Token", resp.ClaimToken)
-	output.Blank()
-	output.Infof(
+	s.output.Successf("User created successfully")
+	s.output.KeyValue("Email", resp.User.Email)
+	s.output.KeyValue("Claim Token", resp.ClaimToken)
+	s.output.Blank()
+	s.output.Infof(
 		"Share this command with the user => %s claim %s",
-		output.Bold(constants.ProjectName),
-		output.Bold(resp.ClaimToken),
+		s.output.Bold(constants.ProjectName),
+		s.output.Bold(resp.ClaimToken),
 	)
-	output.Blank()
-	output.Warningf("⏱  Token expires in 15 minutes")
-	output.Warningf("👁  Can only be viewed once")
+	s.output.Blank()
+	s.output.Warningf("⏱  Token expires in 15 minutes")
+	s.output.Warningf("👁  Can only be viewed once")
+	return nil
+}
+
+// ListUsers lists all users and displays them in a table format
+func (s *UsersService) ListUsers(ctx context.Context) error {
+	s.output.Infof("Listing users…")
+
+	resp, err := s.client.ListUsers(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list users: %w", err)
+	}
+
+	if len(resp.Users) == 0 {
+		s.output.Blank()
+		s.output.Warningf("No users found")
+		return nil
+	}
+
+	rows := s.formatUsers(resp.Users)
+
+	s.output.Blank()
+	s.output.Table(
+		[]string{
+			"Email",
+			"Status",
+			"Created (UTC)",
+			"Last Used (UTC)",
+		},
+		rows,
+	)
+	s.output.Blank()
+	s.output.Successf("Users listed successfully")
+	return nil
+}
+
+// RevokeUser revokes a user's API key
+func (s *UsersService) RevokeUser(ctx context.Context, email string) error {
+	s.output.Infof("Revoking user with email %s...", email)
+
+	resp, err := s.client.RevokeUser(ctx, api.RevokeUserRequest{
+		Email: email,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to revoke user: %w", err)
+	}
+
+	s.output.Successf("User revoked successfully")
+	s.output.KeyValue("Email", resp.Email)
+	return nil
+}
+
+// formatUsers formats user data into table rows
+func (s *UsersService) formatUsers(users []*api.User) [][]string {
+	rows := make([][]string, 0, len(users))
+	for _, u := range users {
+		createdAt := u.CreatedAt.UTC().Format(time.DateTime)
+
+		lastUsed := "Never"
+		if !u.LastUsed.IsZero() {
+			lastUsed = u.LastUsed.UTC().Format(time.DateTime)
+		}
+
+		status := "Active"
+		if u.Revoked {
+			status = "Revoked"
+		}
+
+		rows = append(rows, []string{
+			s.output.Bold(u.Email),
+			status,
+			createdAt,
+			lastUsed,
+		})
+	}
+	return rows
 }

--- a/cmd/runvoy/cmd/users_test.go
+++ b/cmd/runvoy/cmd/users_test.go
@@ -1,0 +1,403 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"runvoy/internal/api"
+)
+
+// mockClientInterfaceForUsers extends mockClientInterface with user management methods
+type mockClientInterfaceForUsers struct {
+	*mockClientInterface
+	createUserFunc func(ctx context.Context, req api.CreateUserRequest) (*api.CreateUserResponse, error)
+	listUsersFunc  func(ctx context.Context) (*api.ListUsersResponse, error)
+	revokeUserFunc func(ctx context.Context, req api.RevokeUserRequest) (*api.RevokeUserResponse, error)
+}
+
+func (m *mockClientInterfaceForUsers) CreateUser(ctx context.Context, req api.CreateUserRequest) (*api.CreateUserResponse, error) {
+	if m.createUserFunc != nil {
+		return m.createUserFunc(ctx, req)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockClientInterfaceForUsers) ListUsers(ctx context.Context) (*api.ListUsersResponse, error) {
+	if m.listUsersFunc != nil {
+		return m.listUsersFunc(ctx)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockClientInterfaceForUsers) RevokeUser(ctx context.Context, req api.RevokeUserRequest) (*api.RevokeUserResponse, error) {
+	if m.revokeUserFunc != nil {
+		return m.revokeUserFunc(ctx, req)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+
+func TestUsersService_CreateUser(t *testing.T) {
+	tests := []struct {
+		name         string
+		email        string
+		setupMock    func(*mockClientInterfaceForUsers)
+		wantErr      bool
+		verifyOutput func(*testing.T, *mockOutputInterface)
+	}{
+		{
+			name:  "successfully creates user",
+			email: "alice@example.com",
+			setupMock: func(m *mockClientInterfaceForUsers) {
+				m.createUserFunc = func(ctx context.Context, req api.CreateUserRequest) (*api.CreateUserResponse, error) {
+					assert.Equal(t, "alice@example.com", req.Email)
+					return &api.CreateUserResponse{
+						User: &api.User{
+							Email:     "alice@example.com",
+							CreatedAt: time.Now(),
+						},
+						ClaimToken: "token-123",
+					}, nil
+				}
+			},
+			wantErr: false,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				hasInfof := false
+				hasSuccess := false
+				hasKeyValue := false
+				hasWarning := false
+				for _, call := range m.calls {
+					if call.method == "Infof" {
+						hasInfof = true
+					}
+					if call.method == "Successf" {
+						hasSuccess = true
+					}
+					if call.method == "KeyValue" && len(call.args) >= 2 {
+						if call.args[0] == "Email" || call.args[0] == "Claim Token" {
+							hasKeyValue = true
+						}
+					}
+					if call.method == "Warningf" {
+						hasWarning = true
+					}
+				}
+				assert.True(t, hasInfof, "Expected Infof call")
+				assert.True(t, hasSuccess, "Expected Successf call")
+				assert.True(t, hasKeyValue, "Expected KeyValue calls")
+				assert.True(t, hasWarning, "Expected Warningf calls for token info")
+			},
+		},
+		{
+			name:  "handles client error",
+			email: "error@example.com",
+			setupMock: func(m *mockClientInterfaceForUsers) {
+				m.createUserFunc = func(ctx context.Context, req api.CreateUserRequest) (*api.CreateUserResponse, error) {
+					return nil, fmt.Errorf("user already exists")
+				}
+			},
+			wantErr: true,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				// Should have Infof but not Successf
+				hasSuccess := false
+				for _, call := range m.calls {
+					if call.method == "Successf" {
+						hasSuccess = true
+					}
+				}
+				assert.False(t, hasSuccess, "Should not have Successf on error")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockClientInterfaceForUsers{
+				mockClientInterface: &mockClientInterface{},
+			}
+			tt.setupMock(mockClient)
+
+			mockOutput := &mockOutputInterface{}
+			service := NewUsersService(mockClient, mockOutput)
+
+			err := service.CreateUser(context.Background(), tt.email)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if tt.verifyOutput != nil {
+				tt.verifyOutput(t, mockOutput)
+			}
+		})
+	}
+}
+
+func TestUsersService_ListUsers(t *testing.T) {
+	tests := []struct {
+		name         string
+		setupMock    func(*mockClientInterfaceForUsers)
+		wantErr      bool
+		verifyOutput func(*testing.T, *mockOutputInterface)
+	}{
+		{
+			name: "successfully lists users",
+			setupMock: func(m *mockClientInterfaceForUsers) {
+				m.listUsersFunc = func(ctx context.Context) (*api.ListUsersResponse, error) {
+					return &api.ListUsersResponse{
+						Users: []*api.User{
+							{
+								Email:     "alice@example.com",
+								CreatedAt: time.Now(),
+								Revoked:   false,
+								LastUsed:  time.Now(),
+							},
+							{
+								Email:     "bob@example.com",
+								CreatedAt: time.Now().Add(-24 * time.Hour),
+								Revoked:   true,
+								LastUsed:  time.Time{},
+							},
+						},
+					}, nil
+				}
+			},
+			wantErr: false,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				hasInfof := false
+				hasTable := false
+				hasSuccess := false
+				for _, call := range m.calls {
+					if call.method == "Infof" {
+						hasInfof = true
+					}
+					if call.method == "Table" {
+						hasTable = true
+					}
+					if call.method == "Successf" {
+						hasSuccess = true
+					}
+				}
+				assert.True(t, hasInfof, "Expected Infof call")
+				assert.True(t, hasTable, "Expected Table call")
+				assert.True(t, hasSuccess, "Expected Successf call")
+			},
+		},
+		{
+			name: "handles empty user list",
+			setupMock: func(m *mockClientInterfaceForUsers) {
+				m.listUsersFunc = func(ctx context.Context) (*api.ListUsersResponse, error) {
+					return &api.ListUsersResponse{
+						Users: []*api.User{},
+					}, nil
+				}
+			},
+			wantErr: false,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				hasWarning := false
+				hasTable := false
+				for _, call := range m.calls {
+					if call.method == "Warningf" {
+						hasWarning = true
+					}
+					if call.method == "Table" {
+						hasTable = true
+					}
+				}
+				assert.True(t, hasWarning, "Expected warning for empty list")
+				assert.False(t, hasTable, "Should not call Table for empty list")
+			},
+		},
+		{
+			name: "handles client error",
+			setupMock: func(m *mockClientInterfaceForUsers) {
+				m.listUsersFunc = func(ctx context.Context) (*api.ListUsersResponse, error) {
+					return nil, fmt.Errorf("network error")
+				}
+			},
+			wantErr: true,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				hasTable := false
+				for _, call := range m.calls {
+					if call.method == "Table" {
+						hasTable = true
+					}
+				}
+				assert.False(t, hasTable, "Should not call Table on error")
+			},
+		},
+		{
+			name: "formats users correctly with revoked status",
+			setupMock: func(m *mockClientInterfaceForUsers) {
+				m.listUsersFunc = func(ctx context.Context) (*api.ListUsersResponse, error) {
+					return &api.ListUsersResponse{
+						Users: []*api.User{
+							{
+								Email:     "revoked@example.com",
+								CreatedAt: time.Now(),
+								Revoked:   true,
+								LastUsed:  time.Time{},
+							},
+						},
+					}, nil
+				}
+			},
+			wantErr: false,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				for _, call := range m.calls {
+					if call.method == "Table" && len(call.args) >= 2 {
+						rows := call.args[1].([][]string)
+						if len(rows) > 0 && len(rows[0]) >= 2 {
+							status := rows[0][1] // Status column
+							assert.Equal(t, "Revoked", status, "Revoked user should show Revoked status")
+						}
+					}
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockClientInterfaceForUsers{
+				mockClientInterface: &mockClientInterface{},
+			}
+			tt.setupMock(mockClient)
+
+			mockOutput := &mockOutputInterface{}
+			service := NewUsersService(mockClient, mockOutput)
+
+			err := service.ListUsers(context.Background())
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if tt.verifyOutput != nil {
+				tt.verifyOutput(t, mockOutput)
+			}
+		})
+	}
+}
+
+func TestUsersService_RevokeUser(t *testing.T) {
+	tests := []struct {
+		name         string
+		email        string
+		setupMock    func(*mockClientInterfaceForUsers)
+		wantErr      bool
+		verifyOutput func(*testing.T, *mockOutputInterface)
+	}{
+		{
+			name:  "successfully revokes user",
+			email: "alice@example.com",
+			setupMock: func(m *mockClientInterfaceForUsers) {
+				m.revokeUserFunc = func(ctx context.Context, req api.RevokeUserRequest) (*api.RevokeUserResponse, error) {
+					assert.Equal(t, "alice@example.com", req.Email)
+					return &api.RevokeUserResponse{
+						Email:   "alice@example.com",
+						Message: "User revoked successfully",
+					}, nil
+				}
+			},
+			wantErr: false,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				hasInfof := false
+				hasSuccess := false
+				hasKeyValue := false
+				for _, call := range m.calls {
+					if call.method == "Infof" {
+						hasInfof = true
+					}
+					if call.method == "Successf" {
+						hasSuccess = true
+					}
+					if call.method == "KeyValue" && len(call.args) >= 2 {
+						if call.args[0] == "Email" {
+							hasKeyValue = true
+						}
+					}
+				}
+				assert.True(t, hasInfof, "Expected Infof call")
+				assert.True(t, hasSuccess, "Expected Successf call")
+				assert.True(t, hasKeyValue, "Expected KeyValue call")
+			},
+		},
+		{
+			name:  "handles user not found error",
+			email: "nonexistent@example.com",
+			setupMock: func(m *mockClientInterfaceForUsers) {
+				m.revokeUserFunc = func(ctx context.Context, req api.RevokeUserRequest) (*api.RevokeUserResponse, error) {
+					return nil, fmt.Errorf("user not found")
+				}
+			},
+			wantErr: true,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				hasSuccess := false
+				for _, call := range m.calls {
+					if call.method == "Successf" {
+						hasSuccess = true
+					}
+				}
+				assert.False(t, hasSuccess, "Should not have Successf on error")
+			},
+		},
+		{
+			name:  "handles network error",
+			email: "error@example.com",
+			setupMock: func(m *mockClientInterfaceForUsers) {
+				m.revokeUserFunc = func(ctx context.Context, req api.RevokeUserRequest) (*api.RevokeUserResponse, error) {
+					return nil, fmt.Errorf("network error")
+				}
+			},
+			wantErr: true,
+			verifyOutput: func(t *testing.T, m *mockOutputInterface) {
+				// Should have Infof but not Successf or KeyValue
+				hasSuccess := false
+				hasKeyValue := false
+				for _, call := range m.calls {
+					if call.method == "Successf" {
+						hasSuccess = true
+					}
+					if call.method == "KeyValue" {
+						hasKeyValue = true
+					}
+				}
+				assert.False(t, hasSuccess, "Should not have Successf on error")
+				assert.False(t, hasKeyValue, "Should not have KeyValue on error")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockClientInterfaceForUsers{
+				mockClientInterface: &mockClientInterface{},
+			}
+			tt.setupMock(mockClient)
+
+			mockOutput := &mockOutputInterface{}
+			service := NewUsersService(mockClient, mockOutput)
+
+			err := service.RevokeUser(context.Background(), tt.email)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if tt.verifyOutput != nil {
+				tt.verifyOutput(t, mockOutput)
+			}
+		})
+	}
+}
+

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -935,7 +935,7 @@ type StatusService struct {
 
 #### CLI Command Testing Architecture
 
-CLI commands are now refactored to use a **service pattern** with dependency injection for testability. This separates business logic from cobra command handlers.
+All CLI commands have been refactored to use a **service pattern** with dependency injection for testability. This separates business logic from cobra command handlers.
 
 **Design Pattern:**
 
@@ -977,19 +977,57 @@ func (s *StatusService) DisplayStatus(ctx context.Context, executionID string) e
 	}
 ```
 
+**Refactored Commands:**
+
+All CLI commands follow the same service pattern:
+
+1. **ClaimCommand** (`claim.go`):
+   - `ClaimService` - Handles API key claiming logic
+   - Includes `ConfigSaver` interface for testable config saving
+   - Full test coverage with error scenarios
+
+2. **KillCommand** (`kill.go`):
+   - `KillService` - Handles execution termination logic
+   - Tests cover success, not found, and network error cases
+
+3. **ListCommand** (`list.go`):
+   - `ListService` - Handles execution listing and table formatting
+   - Tests cover empty lists, formatting, and error handling
+
+4. **ConfigureCommand** (`configure.go`):
+   - `ConfigureService` - Handles interactive configuration flow
+   - Includes `ConfigLoader` and `ConfigPathGetter` interfaces
+   - Supports mocking of prompts for testing
+   - Tests cover new config creation, updates, and error scenarios
+
+5. **UsersCommand** (`users.go`):
+   - `UsersService` - Handles user management (create, list, revoke)
+   - Includes `formatUsers` helper for table formatting
+   - Comprehensive tests for all subcommands
+
+6. **ImagesCommand** (`images.go`):
+   - `ImagesService` - Handles image management (register, list, unregister)
+   - Includes `formatImages` helper for table formatting
+   - Tests cover all image operations
+
 **Key Components:**
 
 1. **Output Interface** (`cmd/runvoy/cmd/output_interface.go`):
-   - Defines `OutputInterface` for all output operations
+   - Defines `OutputInterface` for all output operations including `Prompt()` for interactive commands
    - Provides `outputWrapper` that implements the interface using global `output.*` functions
    - Enables capturing and verifying output in tests
 
 2. **Service Pattern**:
-   - Each command has an associated service (e.g., `StatusService`, `LogsService`)
+   - Each command has an associated service (e.g., `StatusService`, `ClaimService`, `UsersService`)
    - Services contain business logic separated from cobra integration
    - Services accept dependencies via constructor injection
 
-3. **Manual Mocking**:
+3. **Configuration Interfaces**:
+   - `ConfigSaver` - Interface for saving configuration (used by `claim.go`)
+   - `ConfigLoader` - Interface for loading configuration (used by `configure.go`)
+   - `ConfigPathGetter` - Interface for getting config path (used by `configure.go`)
+
+4. **Manual Mocking**:
    - Tests use manual mocks that implement `client.Interface` and `OutputInterface`
    - Mocks are simple structs with function fields for test-specific behavior
    - No external mocking framework required
@@ -1018,7 +1056,14 @@ func TestStatusService_DisplayStatus(t *testing.T) {
 **Refactored Commands:**
 - ✅ `status.go` - Refactored with `StatusService` and full test coverage
 - ✅ `logs.go` - Refactored with `LogsService` and full test coverage
-- ⏳ Other commands follow same pattern when refactored
+- ✅ `claim.go` - Refactored with `ClaimService` and full test coverage
+- ✅ `kill.go` - Refactored with `KillService` and full test coverage
+- ✅ `list.go` - Refactored with `ListService` and full test coverage
+- ✅ `configure.go` - Refactored with `ConfigureService` and full test coverage
+- ✅ `users.go` - Refactored with `UsersService` and full test coverage
+- ✅ `images.go` - Refactored with `ImagesService` and full test coverage
+
+All commands now follow the same service pattern with dependency injection for testability.
 
 **Benefits:**
 - **100% Backward Compatible**: CLI behavior unchanged, only internal structure refactored


### PR DESCRIPTION
Refactor CLI commands to use a service pattern with dependency injection, enhancing testability and separating business logic from command handlers. Updated the following commands: claim, kill, list, configure, users, and images. Ensure all commands follow the same structure for consistency and maintainability. Updated documentation in docs/ARCHITECTURE.md to reflect these changes.