### PR TITLE
Refactor cmd package and consolidate config

### DIFF
--- a/cmd/cli/cmd/claim.go
+++ b/cmd/cli/cmd/claim.go
@@ -40,23 +40,6 @@ func runClaim(cmd *cobra.Command, args []string) {
 	}
 }
 
-// ConfigSaver defines an interface for saving configuration
-type ConfigSaver interface {
-	Save(config *config.Config) error
-}
-
-// configSaverWrapper wraps the global config.Save function to implement ConfigSaver
-type configSaverWrapper struct{}
-
-func (c *configSaverWrapper) Save(cfg *config.Config) error {
-	return config.Save(cfg)
-}
-
-// NewConfigSaver creates a new ConfigSaver that uses the global config.Save function
-func NewConfigSaver() ConfigSaver {
-	return &configSaverWrapper{}
-}
-
 // ClaimService handles API key claiming logic
 type ClaimService struct {
 	client      client.Interface

--- a/cmd/cli/cmd/configure_test.go
+++ b/cmd/cli/cmd/configure_test.go
@@ -260,8 +260,8 @@ func TestConfigureService_Configure(t *testing.T) {
 			service := NewConfigureService(
 				mockOutput,
 				mockSaver,
-				mockLoader.Load,
-				tt.setupPathGetter,
+				mockLoader,
+				ConfigPathGetterFunc(tt.setupPathGetter),
 			)
 
 			err := service.Configure(context.Background())


### PR DESCRIPTION
Consolidate config interfaces and their function adapters into `cmd/cli/cmd/configure.go` to reduce code duplication and improve organization.

---
<a href="https://cursor.com/background-agent?bcId=bc-85e5a231-eed0-439a-b4b7-06d8b5662dec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-85e5a231-eed0-439a-b4b7-06d8b5662dec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

