### PR TITLE
Update task state handling for more events

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ runvoy run --git-repo https://github.com/mycompany/myproject.git npm run tests
 # → Running command: npm run tests
 # ✓ Command execution started successfully
 #   Execution ID: 61fb9138466c4212b1e0d763a7f4dfe2
-#   Status: RUNNING
+#   Status: STARTING
 # → Logs not available yet, waiting 10 seconds... (attempt 1/3)
 # → Logs not available yet, waiting 10 seconds... (attempt 2/3)
 #
@@ -413,7 +413,7 @@ The web viewer is a minimal, single-page application that provides:
 
 - **Real-time log streaming** - Automatically get updates from the websocket API in real-time
 - **ANSI color support** - Displays colored terminal output
-- **Status tracking** - Shows execution status (RUNNING, SUCCEEDED, FAILED, STOPPED)
+- **Status tracking** - Shows execution status (STARTING, RUNNING, SUCCEEDED, FAILED, STOPPED, TERMINATING)
 - **Execution metadata** - Displays execution ID, start time, and exit codes
 - **Interactive controls**:
   - Pause/Resume streaming

--- a/cmd/webapp/src/components/StatusBar.svelte
+++ b/cmd/webapp/src/components/StatusBar.svelte
@@ -110,6 +110,10 @@
     .status-badge.loading {
         background-color: #78909c;
     } /* Blue Grey */
+    .status-badge.starting {
+        background-color: #64b5f6;
+        color: #000;
+    } /* Light Blue */
     .status-badge.running {
         background-color: #2196f3;
     } /* Blue */
@@ -122,4 +126,8 @@
     .status-badge.stopped {
         background-color: #ff9800;
     } /* Orange */
+    .status-badge.terminating {
+        background-color: #ff7043;
+        color: #000;
+    } /* Orange-Red */
 </style>

--- a/cmd/webapp/src/styles/global.css
+++ b/cmd/webapp/src/styles/global.css
@@ -57,6 +57,11 @@
     white-space: nowrap;
 }
 
+.status.STARTING {
+    background: #64b5f6;
+    color: #000;
+}
+
 .status.RUNNING {
     background: #ffa500;
     color: #000;
@@ -74,6 +79,11 @@
 
 .status.STOPPED {
     background: #9e9e9e;
+    color: #000;
+}
+
+.status.TERMINATING {
+    background: #ff7043;
     color: #000;
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -79,7 +79,7 @@ DELETE /api/v1/images/{image}           - Remove a registered Docker image (admi
 POST   /api/v1/run                      - Start an execution
 GET    /api/v1/executions               - List executions (queried via DynamoDB GSI)
 GET    /api/v1/executions/{id}/logs     - Fetch execution logs (CloudWatch)
-GET    /api/v1/executions/{id}/status   - Get execution status (RUNNING/SUCCEEDED/FAILED/STOPPED)
+GET    /api/v1/executions/{id}/status   - Get execution status (STARTING/RUNNING/SUCCEEDED/FAILED/STOPPED/TERMINATING)
 POST   /api/v1/executions/{id}/kill     - Terminate a running execution
 GET    /api/v1/claim/{token}            - Claim a pending API key (public, no auth required)
 ```
@@ -716,7 +716,7 @@ The platform includes a minimal web-based log viewer for visualizing execution l
    - Maintains terminal formatting in the browser
 
 3. **Status Tracking**
-   - Displays execution status (RUNNING, SUCCEEDED, FAILED, STOPPED)
+   - Displays execution status (STARTING, RUNNING, SUCCEEDED, FAILED, STOPPED, TERMINATING)
    - Shows execution metadata (ID, start time, exit codes)
    - Updates in real-time as execution progresses
 
@@ -1323,7 +1323,7 @@ The `run` command executes commands remotely via the orchestrator Lambda.
    ```
 3. Orchestrator Lambda:
    - Validates API key
-   - Creates execution record in DynamoDB (status: RUNNING)
+   - Creates execution record in DynamoDB (status: STARTING)
    - Starts ECS Fargate task with the command and sidecar
    - Returns execution ID
 
@@ -1332,7 +1332,7 @@ The `run` command executes commands remotely via the orchestrator Lambda.
 {
   "execution_id": "abc123...",
   "log_url": "/api/v1/executions/abc123/logs/notimplemented",
-  "status": "RUNNING"
+  "status": "STARTING"
 }
 ```
 
@@ -1505,7 +1505,7 @@ Stores execution records for all command runs.
 - `command` (String) - The command that was executed
 - `lock_name` (String, optional) - Lock name if specified
 - `completed_at` (String, optional) - ISO 8601 timestamp when execution completed
-- `status` (String) - Current status (RUNNING, SUCCEEDED, FAILED, STOPPED)
+- `status` (String) - Current status (STARTING, RUNNING, SUCCEEDED, FAILED, STOPPED, TERMINATING)
 - `exit_code` (Number) - Exit code from the command
 - `duration_seconds` (Number, optional) - Execution duration in seconds
 - `log_stream_name` (String, optional) - CloudWatch Logs stream name

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -89,7 +89,7 @@ type LogsResponse struct {
 	ExecutionID string     `json:"execution_id"`
 	Events      []LogEvent `json:"events"`
 
-	// Current execution status (RUNNING, SUCCEEDED, FAILED, STOPPED)
+	// Current execution status (STARTING, RUNNING, SUCCEEDED, FAILED, STOPPED, TERMINATING)
 	Status string `json:"status"`
 
 	// WebSocket URL for streaming logs (only provided if execution is RUNNING)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -433,7 +433,7 @@ func TestClient_RunCommand(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(api.ExecutionResponse{
 				ExecutionID: "exec-123",
 				LogURL:      "https://example.com/logs/exec-123",
-				Status:      "RUNNING",
+				Status:      "STARTING",
 			})
 		}))
 		defer server.Close()
@@ -451,7 +451,7 @@ func TestClient_RunCommand(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		assert.Equal(t, "exec-123", resp.ExecutionID)
-		assert.Equal(t, "RUNNING", resp.Status)
+		assert.Equal(t, "STARTING", resp.Status)
 	})
 }
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -123,6 +123,8 @@ const (
 type ExecutionStatus string
 
 const (
+	// ExecutionStarting indicates the command has been scheduled and is preparing to run
+	ExecutionStarting ExecutionStatus = "STARTING"
 	// ExecutionRunning indicates the command is currently executing
 	ExecutionRunning ExecutionStatus = "RUNNING"
 	// ExecutionSucceeded indicates the command completed successfully
@@ -131,6 +133,8 @@ const (
 	ExecutionFailed ExecutionStatus = "FAILED"
 	// ExecutionStopped indicates the command was manually terminated
 	ExecutionStopped ExecutionStatus = "STOPPED"
+	// ExecutionTerminating indicates a termination request has been issued and is in progress
+	ExecutionTerminating ExecutionStatus = "TERMINATING"
 )
 
 // TerminalExecutionStatuses returns all statuses that represent completed executions

--- a/internal/constants/constants_test.go
+++ b/internal/constants/constants_test.go
@@ -133,10 +133,12 @@ func TestEcsStatus(t *testing.T) {
 
 func TestExecutionStatus(t *testing.T) {
 	t.Run("execution status constants are set", func(t *testing.T) {
+		assert.Equal(t, ExecutionStatus("STARTING"), ExecutionStarting)
 		assert.Equal(t, ExecutionStatus("RUNNING"), ExecutionRunning)
 		assert.Equal(t, ExecutionStatus("SUCCEEDED"), ExecutionSucceeded)
 		assert.Equal(t, ExecutionStatus("FAILED"), ExecutionFailed)
 		assert.Equal(t, ExecutionStatus("STOPPED"), ExecutionStopped)
+		assert.Equal(t, ExecutionStatus("TERMINATING"), ExecutionTerminating)
 	})
 }
 
@@ -149,6 +151,8 @@ func TestTerminalExecutionStatuses(t *testing.T) {
 		assert.Contains(t, statuses, ExecutionFailed)
 		assert.Contains(t, statuses, ExecutionStopped)
 		assert.NotContains(t, statuses, ExecutionRunning, "RUNNING should not be terminal")
+		assert.NotContains(t, statuses, ExecutionStarting, "STARTING should not be terminal")
+		assert.NotContains(t, statuses, ExecutionTerminating, "TERMINATING should not be terminal")
 	})
 
 	t.Run("terminal statuses are unique", func(t *testing.T) {

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -265,7 +265,7 @@ func TestHandleRunCommand_Success(t *testing.T) {
 	err := json.NewDecoder(resp.Body).Decode(&execResp)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, execResp.ExecutionID)
-	assert.Equal(t, string(constants.ExecutionRunning), execResp.Status)
+	assert.Equal(t, string(constants.ExecutionStarting), execResp.Status)
 }
 
 func TestHandleRunCommand_InvalidJSON(t *testing.T) {


### PR DESCRIPTION
Add `STARTING` and `TERMINATING` execution states to improve task lifecycle tracking (gh issue #174).

Previously, only `RUNNING`, `STOPPED`, and `COMPLETED` states were tracked. This PR introduces `STARTING` when a task is initiated and `TERMINATING` when a kill request is issued, allowing for more granular visibility into the task's transitional phases. ECS events now explicitly promote tasks from `STARTING` to `RUNNING`.

---
<a href="https://cursor.com/background-agent?bcId=bc-b05c6a29-7fa4-49b7-93b5-022f7ad6de5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b05c6a29-7fa4-49b7-93b5-022f7ad6de5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

