### PR TITLE
Unentangle event processor from aws

### DIFF
--- a/cmd/backend/aws/event_processor/main.go
+++ b/cmd/backend/aws/event_processor/main.go
@@ -9,7 +9,7 @@ import (
 
 	"runvoy/internal/config"
 	"runvoy/internal/constants"
-	"runvoy/internal/events"
+	eventsaws "runvoy/internal/events/providers/aws"
 	"runvoy/internal/logger"
 
 	"github.com/aws/aws-lambda-go/lambda"
@@ -20,7 +20,7 @@ func main() {
 	log := logger.Initialize(constants.Production, cfg.GetLogLevel())
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.InitTimeout)
 
-	processor, err := events.NewProcessor(ctx, cfg, log)
+	processor, err := eventsaws.NewProcessor(ctx, cfg, log)
 	cancel()
 	if err != nil {
 		log.Error("failed to create event processor", "error", err)

--- a/cmd/local/main.go
+++ b/cmd/local/main.go
@@ -17,6 +17,7 @@ import (
 	"runvoy/internal/config"
 	"runvoy/internal/constants"
 	"runvoy/internal/events"
+	eventsaws "runvoy/internal/events/providers/aws"
 	"runvoy/internal/logger"
 	serverPkg "runvoy/internal/server"
 )
@@ -30,7 +31,7 @@ func initializeServices(ctx context.Context, log *slog.Logger, oCfg *config.Conf
 		return nil, nil, fmt.Errorf("failed to initialize orchestrator service: %w", err)
 	}
 
-	processor, err := events.NewProcessor(ctx, eCfg, log)
+	processor, err := eventsaws.NewProcessor(ctx, eCfg, log)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to initialize event processor: %w", err)
 	}

--- a/internal/events/ecs_completion.go
+++ b/internal/events/ecs_completion.go
@@ -174,15 +174,18 @@ func determineStatusAndExitCode(event *ECSTaskStateChangeEvent) (status string, 
 // ECSCompletionHandler is a factory function that returns a handler for ECS completion events
 func ECSCompletionHandler(
 	executionRepo database.ExecutionRepository,
-	connectionRepo database.ConnectionRepository,
 	websocketManager websocket.Manager,
 	log *slog.Logger) func(context.Context, events.CloudWatchEvent) error {
 	return func(ctx context.Context, event events.CloudWatchEvent) error {
-		p := &Processor{
-			executionRepo:    executionRepo,
-			connectionRepo:   connectionRepo,
-			webSocketManager: websocketManager,
-			logger:           log,
+		p, err := NewProcessor(
+			ProcessorDependencies{
+				ExecutionRepo:    executionRepo,
+				WebSocketManager: websocketManager,
+			},
+			log,
+		)
+		if err != nil {
+			return err
 		}
 		return p.handleECSTaskCompletion(ctx, &event)
 	}

--- a/internal/events/providers/aws/processor.go
+++ b/internal/events/providers/aws/processor.go
@@ -1,0 +1,50 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"runvoy/internal/config"
+	dynamorepo "runvoy/internal/database/dynamodb"
+	"runvoy/internal/events"
+	"runvoy/internal/websocket"
+
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	awsdynamodb "github.com/aws/aws-sdk-go-v2/service/dynamodb"
+)
+
+// NewProcessor builds an AWS-backed event processor with DynamoDB repositories and API Gateway WebSocket manager.
+func NewProcessor(ctx context.Context, cfg *config.Config, log *slog.Logger) (*events.Processor, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("configuration is required")
+	}
+	if log == nil {
+		return nil, fmt.Errorf("logger is required")
+	}
+
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load AWS configuration: %w", err)
+	}
+
+	dynamoClient := awsdynamodb.NewFromConfig(awsCfg)
+	executionRepo := dynamorepo.NewExecutionRepository(dynamoClient, cfg.ExecutionsTable, log)
+	connectionRepo := dynamorepo.NewConnectionRepository(dynamoClient, cfg.WebSocketConnectionsTable, log)
+	tokenRepo := dynamorepo.NewTokenRepository(dynamoClient, cfg.WebSocketTokensTable, log)
+	websocketManager := websocket.NewWebSocketManager(cfg, &awsCfg, connectionRepo, tokenRepo, log)
+
+	log.Debug("event processor initialized",
+		"context", map[string]string{
+			"executions_table":             cfg.ExecutionsTable,
+			"web_socket_connections_table": cfg.WebSocketConnectionsTable,
+			"web_socket_tokens_table":      cfg.WebSocketTokensTable,
+			"websocket_api_endpoint":       cfg.WebSocketAPIEndpoint,
+		},
+	)
+
+	return events.NewProcessor(events.ProcessorDependencies{
+		ExecutionRepo:    executionRepo,
+		WebSocketManager: websocketManager,
+	}, log)
+}


### PR DESCRIPTION
Decouple the event processor core from AWS-specific implementations by introducing a provider pattern.

This change moves AWS client and repository instantiation into a dedicated AWS provider, allowing the core event processor to depend on interfaces, making it easier to support other cloud providers.

---
<a href="https://cursor.com/background-agent?bcId=bc-6fc25e53-6b16-4493-abbf-376413f8171c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6fc25e53-6b16-4493-abbf-376413f8171c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

