### PR TITLE
Streamline multi-cloud support architecture

### DIFF
--- a/internal/events/init.go
+++ b/internal/events/init.go
@@ -10,7 +10,7 @@ import (
 	"runvoy/internal/constants"
 	dynamoRepo "runvoy/internal/database/dynamodb"
 	eventsAws "runvoy/internal/events/aws"
-	"runvoy/internal/websocket"
+	websocketAws "runvoy/internal/websocket/aws"
 
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -81,7 +81,7 @@ func initializeAWSBackend(
 	connectionRepo := dynamoRepo.NewConnectionRepository(dynamoClient, cfg.WebSocketConnectionsTable, logger)
 	tokenRepo := dynamoRepo.NewTokenRepository(dynamoClient, cfg.WebSocketTokensTable, logger)
 
-	websocketManager := websocket.NewWebSocketManager(cfg, &awsCfg, connectionRepo, tokenRepo, logger)
+	websocketManager := websocketAws.NewManager(cfg, &awsCfg, connectionRepo, tokenRepo, logger)
 
 	backend := eventsAws.NewBackend(executionRepo, websocketManager, logger)
 

--- a/internal/websocket/aws/manager_test.go
+++ b/internal/websocket/aws/manager_test.go
@@ -1,4 +1,4 @@
-package websocket
+package aws
 
 import (
 	"context"
@@ -115,7 +115,7 @@ func TestValidateConnectionParams(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			wm := &WebSocketManager{logger: testutil.SilentLogger()}
+			wm := &Manager{logger: testutil.SilentLogger()}
 
 			resp := wm.validateConnectionParams(tt.connectionID, tt.executionID, tt.token)
 
@@ -267,7 +267,7 @@ func TestHandleConnect(t *testing.T) {
 				},
 			}
 
-			wm := &WebSocketManager{
+			wm := &Manager{
 				connRepo:  mockConnRepo,
 				tokenRepo: mockTokenRepo,
 				logger:    testutil.SilentLogger(),
@@ -318,7 +318,7 @@ func TestHandleConnect_UsesTokenMetadata(t *testing.T) {
 		},
 	}
 
-	wm := &WebSocketManager{
+	wm := &Manager{
 		connRepo:  mockConnRepo,
 		tokenRepo: mockTokenRepo,
 		logger:    testutil.SilentLogger(),

--- a/internal/websocket/manager.go
+++ b/internal/websocket/manager.go
@@ -1,0 +1,26 @@
+// Package websocket provides WebSocket management for runvoy.
+// It handles connection lifecycle events and manages WebSocket connections.
+package websocket
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	"runvoy/internal/api"
+)
+
+// Manager exposes the subset of WebSocket manager functionality used by the event processor.
+// Different cloud providers can implement this interface to support their specific WebSocket infrastructure.
+type Manager interface {
+	// HandleRequest processes WebSocket lifecycle events (connect, disconnect, etc.).
+	// Returns true if the event was handled, false otherwise.
+	HandleRequest(ctx context.Context, rawEvent *json.RawMessage, reqLogger *slog.Logger) (bool, error)
+
+	// NotifyExecutionCompletion sends disconnect notifications to all connected clients for an execution
+	// and removes the connections.
+	NotifyExecutionCompletion(ctx context.Context, executionID *string) error
+
+	// SendLogsToExecution sends log events to all connected clients for an execution.
+	SendLogsToExecution(ctx context.Context, executionID *string, logEvents []api.LogEvent) error
+}


### PR DESCRIPTION
Apply the same extensibility pattern used for orchestrator and event processor to the WebSocket manager, making it easier to extend runvoy to support other cloud providers.

Changes:
- Create websocket.Manager interface to define the contract
- Move AWS-specific implementation to internal/websocket/aws/manager.go
- Update initialization code to use the new aws subpackage
- Move and update tests to the aws subpackage

This allows future implementations for other cloud providers (GCP, Azure) to be added as separate packages (e.g., internal/websocket/gcp/) without modifying the core interface.