### PR TITLE
Integrate config logic into validation layer

### DIFF
--- a/cmd/backend/providers/aws/event_processor/main.go
+++ b/cmd/backend/providers/aws/event_processor/main.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"log/slog"
 	"os"
 
 	"runvoy/internal/config"
@@ -18,11 +17,7 @@ import (
 
 func main() {
 	cfg := config.MustLoadEventProcessor()
-	var level slog.Level
-	if err := level.UnmarshalText([]byte(cfg.LogLevel)); err != nil {
-		level = slog.LevelInfo
-	}
-	log := logger.Initialize(constants.Production, level)
+	log := logger.Initialize(constants.Production, cfg.LogLevel)
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.InitTimeout)
 
 	processor, err := events.Initialize(ctx, cfg, log)

--- a/cmd/backend/providers/aws/orchestrator/main.go
+++ b/cmd/backend/providers/aws/orchestrator/main.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"context"
-	"log/slog"
 	"os"
 
 	"runvoy/internal/app"
@@ -18,11 +17,7 @@ import (
 
 func main() {
 	cfg := config.MustLoadOrchestrator()
-	var level slog.Level
-	if err := level.UnmarshalText([]byte(cfg.LogLevel)); err != nil {
-		level = slog.LevelInfo
-	}
-	log := logger.Initialize(constants.Production, level)
+	log := logger.Initialize(constants.Production, cfg.LogLevel)
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.InitTimeout)
 
 	svc, err := app.Initialize(ctx, constants.AWS, cfg, log)

--- a/cmd/local/main.go
+++ b/cmd/local/main.go
@@ -46,7 +46,7 @@ func startOrchestratorServer(log *slog.Logger, cfg *config.Config, svc *app.Serv
 		log.Info("starting orchestrator server",
 			"port", cfg.Port,
 			"version", *constants.GetVersion(),
-			"log_level", cfg.LogLevel,
+			"log_level", cfg.LogLevel.String(),
 			"request_timeout", cfg.RequestTimeout,
 		)
 		log.Debug("orchestrator health check available",
@@ -86,7 +86,7 @@ func startAsyncProcessorServer(log *slog.Logger, cfg *config.Config, processor *
 		log.Info("starting async processor server",
 			"port", port,
 			"version", *constants.GetVersion(),
-			"log_level", cfg.LogLevel,
+			"log_level", cfg.LogLevel.String(),
 		)
 		log.Debug("async processor endpoint available",
 			"url", fmt.Sprintf("http://localhost:%d/process", port),
@@ -159,11 +159,7 @@ func main() {
 	orchestratorCfg := config.MustLoadOrchestrator()
 	eventProcessorCfg := config.MustLoadEventProcessor()
 
-	var level slog.Level
-	if err := level.UnmarshalText([]byte(orchestratorCfg.LogLevel)); err != nil {
-		level = slog.LevelInfo
-	}
-	log := logger.Initialize(constants.Development, level)
+	log := logger.Initialize(constants.Development, orchestratorCfg.LogLevel)
 
 	ctx, cancel := context.WithTimeout(context.Background(), orchestratorCfg.InitTimeout)
 	svc, processor, initErr := initializeServices(ctx, log, orchestratorCfg, eventProcessorCfg)

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHP
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,59 +11,58 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNormalizeLogLevel(t *testing.T) {
+func TestParseLogLevel(t *testing.T) {
 	tests := []struct {
 		name     string
 		logLevel string
-		expected string
+		expected slog.Level
 	}{
 		{
 			name:     "DEBUG level stays uppercase",
 			logLevel: "DEBUG",
-			expected: slog.LevelDebug.String(),
+			expected: slog.LevelDebug,
 		},
 		{
 			name:     "INFO level stays uppercase",
 			logLevel: "INFO",
-			expected: slog.LevelInfo.String(),
+			expected: slog.LevelInfo,
 		},
 		{
 			name:     "WARN level stays uppercase",
 			logLevel: "WARN",
-			expected: slog.LevelWarn.String(),
+			expected: slog.LevelWarn,
 		},
 		{
 			name:     "ERROR level stays uppercase",
 			logLevel: "ERROR",
-			expected: slog.LevelError.String(),
+			expected: slog.LevelError,
 		},
 		{
 			name:     "invalid level defaults to INFO",
 			logLevel: "INVALID",
-			expected: slog.LevelInfo.String(),
+			expected: slog.LevelInfo,
 		},
 		{
 			name:     "empty string defaults to INFO",
 			logLevel: "",
-			expected: slog.LevelInfo.String(),
+			expected: slog.LevelInfo,
 		},
 		{
 			name:     "lowercase level is normalized to uppercase",
 			logLevel: "debug",
-			expected: slog.LevelDebug.String(),
+			expected: slog.LevelDebug,
 		},
 		{
 			name:     "whitespace trimmed",
 			logLevel: "  warn  ",
-			expected: slog.LevelWarn.String(),
+			expected: slog.LevelWarn,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := &Config{LogLevel: tt.logLevel}
-			normalizeLogLevel(cfg)
-			assert.Equal(t, tt.expected, cfg.LogLevel)
+			level := parseLogLevel(tt.logLevel)
+			assert.Equal(t, tt.expected, level)
 		})
 	}
 }
@@ -493,7 +492,7 @@ func TestConfigStruct(t *testing.T) {
 			APIEndpoint: "https://api.example.com",
 			APIKey:      "test-key",
 			Port:        8080,
-			LogLevel:    "INFO",
+			LogLevel:    slog.LevelInfo,
 			AWS: &awsconfig.Config{
 				APIKeysTable:        "api-keys-table",
 				ExecutionsTable:     "executions-table",
@@ -512,7 +511,7 @@ func TestConfigStruct(t *testing.T) {
 		assert.NotNil(t, cfg)
 		assert.Equal(t, "https://api.example.com", cfg.APIEndpoint)
 		assert.Equal(t, "test-key", cfg.APIKey)
-		assert.Equal(t, "INFO", cfg.LogLevel)
+		assert.Equal(t, slog.LevelInfo, cfg.LogLevel)
 		assert.NotNil(t, cfg.AWS)
 		assert.Equal(t, "test-cluster", cfg.AWS.ECSCluster)
 	})


### PR DESCRIPTION
Normalize `Config.LogLevel` during configuration loading to ensure it's always a valid and canonical `slog.Level` string, allowing safe direct use.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e74d35a-188e-48fa-8ea2-f75530bc849a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5e74d35a-188e-48fa-8ea2-f75530bc849a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

