### PR TITLE
Remove duplicate token generation functions

### DIFF
--- a/internal/app/main.go
+++ b/internal/app/main.go
@@ -107,7 +107,7 @@ func generateOrUseAPIKey(providedKey string) (string, error) {
 	if providedKey != "" {
 		return providedKey, nil
 	}
-	apiKey, err := auth.GenerateAPIKey()
+	apiKey, err := auth.GenerateSecretToken()
 	if err != nil {
 		return "", apperrors.ErrInternalError("failed to generate API key", err)
 	}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -9,17 +9,6 @@ import (
 	"runvoy/internal/constants"
 )
 
-// GenerateAPIKey creates a cryptographically secure random API key.
-// The key is base64-encoded and approximately 32 characters long.
-func GenerateAPIKey() (string, error) {
-	b := make([]byte, constants.APIKeyByteSize)
-	if _, err := rand.Read(b); err != nil {
-		return "", err
-	}
-
-	return base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(b), nil
-}
-
 // HashAPIKey creates a SHA-256 hash of the API key for secure storage.
 // NOTICE: we never store plain API keys in the database.
 func HashAPIKey(apiKey string) string {

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -10,43 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGenerateAPIKey(t *testing.T) {
-	tests := []struct {
-		name string
-	}{
-		{name: "generates valid API key"},
-		{name: "generates unique keys on multiple calls"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			key, err := GenerateAPIKey()
-
-			require.NoError(t, err, "GenerateAPIKey should not return an error")
-			assert.NotEmpty(t, key, "Generated key should not be empty")
-
-			// Verify it's base64 URL encoded
-			_, err = base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(key)
-			assert.NoError(t, err, "Key should be valid base64 URL encoding")
-
-			// Verify minimum length (24 bytes encoded should be ~32 chars)
-			assert.GreaterOrEqual(t, len(key), 30, "Key should be at least 30 characters")
-
-			// Verify it doesn't contain invalid characters
-			assert.True(t, isValidBase64URL(key), "Key should only contain valid base64 URL characters")
-		})
-	}
-
-	t.Run("generates unique keys", func(t *testing.T) {
-		key1, err1 := GenerateAPIKey()
-		key2, err2 := GenerateAPIKey()
-
-		require.NoError(t, err1)
-		require.NoError(t, err2)
-		assert.NotEqual(t, key1, key2, "Two consecutive API keys should be different")
-	})
-}
-
 func TestHashAPIKey(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -126,13 +89,6 @@ func isValidBase64URL(s string) bool {
 func computeExpectedHash(input string) string {
 	hash := sha256.Sum256([]byte(input))
 	return base64.StdEncoding.EncodeToString(hash[:])
-}
-
-// Benchmark for API key generation
-func BenchmarkGenerateAPIKey(b *testing.B) {
-	for b.Loop() {
-		_, _ = GenerateAPIKey()
-	}
 }
 
 func TestGenerateSecretToken(t *testing.T) {

--- a/scripts/seed-admin-user/main.go
+++ b/scripts/seed-admin-user/main.go
@@ -30,7 +30,7 @@ type userItem struct {
 
 func setupAPIKeyAndConfig() (cfg *config.Config, apiKey, apiKeyHash string) {
 	var err error
-	apiKey, err = auth.GenerateAPIKey()
+	apiKey, err = auth.GenerateSecretToken()
 	if err != nil {
 		log.Fatalf("error: failed to generate API key: %v", err)
 	}


### PR DESCRIPTION
- Removed GenerateAPIKey() function as it was identical to GenerateSecretToken()
- Updated all usages to use GenerateSecretToken() instead
- Removed redundant GenerateAPIKey tests
- Renamed apikey.go to auth.go and apikey_test.go to auth_test.go
- Both functions used the same byte size (24) and encoding method

This consolidation reduces code duplication while maintaining all functionality.