### PR TITLE
Move log level validation to config package

### DIFF
--- a/cmd/backend/providers/aws/event_processor/main.go
+++ b/cmd/backend/providers/aws/event_processor/main.go
@@ -17,7 +17,7 @@ import (
 
 func main() {
 	cfg := config.MustLoadEventProcessor()
-	log := logger.Initialize(constants.Production, cfg.GetLogLevel())
+	log := logger.Initialize(constants.Production, cfg.LogLevel)
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.InitTimeout)
 
 	processor, err := events.Initialize(ctx, cfg, log)

--- a/cmd/backend/providers/aws/orchestrator/main.go
+++ b/cmd/backend/providers/aws/orchestrator/main.go
@@ -17,7 +17,7 @@ import (
 
 func main() {
 	cfg := config.MustLoadOrchestrator()
-	log := logger.Initialize(constants.Production, cfg.GetLogLevel())
+	log := logger.Initialize(constants.Production, cfg.LogLevel)
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.InitTimeout)
 
 	svc, err := app.Initialize(ctx, constants.AWS, cfg, log)

--- a/cmd/local/main.go
+++ b/cmd/local/main.go
@@ -159,7 +159,7 @@ func main() {
 	orchestratorCfg := config.MustLoadOrchestrator()
 	eventProcessorCfg := config.MustLoadEventProcessor()
 
-	log := logger.Initialize(constants.Development, orchestratorCfg.GetLogLevel())
+	log := logger.Initialize(constants.Development, orchestratorCfg.LogLevel)
 
 	ctx, cancel := context.WithTimeout(context.Background(), orchestratorCfg.InitTimeout)
 	svc, processor, initErr := initializeServices(ctx, log, orchestratorCfg, eventProcessorCfg)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,7 +30,7 @@ type Config struct {
 	// Backend Service Configuration
 	BackendProvider constants.BackendProvider `mapstructure:"backend_provider" yaml:"backend_provider"`
 	InitTimeout     time.Duration             `mapstructure:"init_timeout"`
-	LogLevel        string                    `mapstructure:"log_level"`
+	LogLevel        slog.Level                `mapstructure:"log_level"`
 	Port            int                       `mapstructure:"port" validate:"omitempty"`
 	RequestTimeout  time.Duration             `mapstructure:"request_timeout"`
 
@@ -209,16 +209,6 @@ func GetConfigPath() (string, error) {
 
 	configDir := constants.ConfigDirPath(currentUser.HomeDir)
 	return filepath.Join(configDir, constants.ConfigFileName), nil
-}
-
-// GetLogLevel returns the slog.Level from the string configuration.
-// Defaults to INFO if the level string is invalid.
-func (c *Config) GetLogLevel() slog.Level {
-	var level slog.Level
-	if err := level.UnmarshalText([]byte(c.LogLevel)); err != nil {
-		return slog.LevelInfo
-	}
-	return level
 }
 
 // Helper functions

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,54 +11,38 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConfig_GetLogLevel(t *testing.T) {
+func TestConfig_LogLevel(t *testing.T) {
 	tests := []struct {
 		name     string
-		logLevel string
+		logLevel slog.Level
 		expected slog.Level
 	}{
 		{
 			name:     "DEBUG level",
-			logLevel: "DEBUG",
+			logLevel: slog.LevelDebug,
 			expected: slog.LevelDebug,
 		},
 		{
 			name:     "INFO level",
-			logLevel: "INFO",
+			logLevel: slog.LevelInfo,
 			expected: slog.LevelInfo,
 		},
 		{
 			name:     "WARN level",
-			logLevel: "WARN",
+			logLevel: slog.LevelWarn,
 			expected: slog.LevelWarn,
 		},
 		{
 			name:     "ERROR level",
-			logLevel: "ERROR",
+			logLevel: slog.LevelError,
 			expected: slog.LevelError,
-		},
-		{
-			name:     "invalid level defaults to INFO",
-			logLevel: "INVALID",
-			expected: slog.LevelInfo,
-		},
-		{
-			name:     "empty string defaults to INFO",
-			logLevel: "",
-			expected: slog.LevelInfo,
-		},
-		{
-			name:     "lowercase level",
-			logLevel: "debug",
-			expected: slog.LevelDebug,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &Config{LogLevel: tt.logLevel}
-			result := cfg.GetLogLevel()
-			assert.Equal(t, tt.expected, result)
+			assert.Equal(t, tt.expected, cfg.LogLevel)
 		})
 	}
 }
@@ -488,7 +472,7 @@ func TestConfigStruct(t *testing.T) {
 			APIEndpoint: "https://api.example.com",
 			APIKey:      "test-key",
 			Port:        8080,
-			LogLevel:    "INFO",
+			LogLevel:    slog.LevelInfo,
 			AWS: &awsconfig.Config{
 				APIKeysTable:        "api-keys-table",
 				ExecutionsTable:     "executions-table",
@@ -507,7 +491,7 @@ func TestConfigStruct(t *testing.T) {
 		assert.NotNil(t, cfg)
 		assert.Equal(t, "https://api.example.com", cfg.APIEndpoint)
 		assert.Equal(t, "test-key", cfg.APIKey)
-		assert.Equal(t, "INFO", cfg.LogLevel)
+		assert.Equal(t, slog.LevelInfo, cfg.LogLevel)
 		assert.NotNil(t, cfg.AWS)
 		assert.Equal(t, "test-cluster", cfg.AWS.ECSCluster)
 	})
@@ -518,11 +502,10 @@ func TestSetDefaults(t *testing.T) {
 		// This test verifies the behavior indirectly by checking if defaults
 		// are reasonable. Direct testing would require exposing setDefaults.
 		cfg := &Config{
-			LogLevel: "INFO",
+			LogLevel: slog.LevelInfo,
 		}
 
-		level := cfg.GetLogLevel()
-		assert.Equal(t, slog.LevelInfo, level)
+		assert.Equal(t, slog.LevelInfo, cfg.LogLevel)
 	})
 }
 


### PR DESCRIPTION
- Change LogLevel field type from string to slog.Level in Config struct
- Remove GetLogLevel() helper method
- Update all usages to reference cfg.LogLevel directly
- Update tests to reflect new type

This change moves log level validation to the config unmarshaling layer. Invalid log levels will now cause config loading to fail with a proper error, rather than silently defaulting to INFO. The slog.Level type automatically handles validation via its UnmarshalText implementation.