### PR TITLE
Move request id generation to auth package

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -5,6 +5,8 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
+	"time"
 
 	"runvoy/internal/constants"
 )
@@ -27,4 +29,15 @@ func GenerateSecretToken() (string, error) {
 	}
 
 	return base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(b), nil
+}
+
+// GenerateRequestID generates a random request ID using crypto/rand.
+// Used for request tracing and logging. Returns a hex-encoded string.
+// If random generation fails, falls back to a time-based identifier.
+func GenerateRequestID() string {
+	b := make([]byte, constants.RequestIDByteSize)
+	if _, err := rand.Read(b); err != nil {
+		return hex.EncodeToString([]byte(time.Now().String()))
+	}
+	return hex.EncodeToString(b)
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"strings"
 	"testing"
 
@@ -119,6 +120,33 @@ func TestGenerateSecretToken(t *testing.T) {
 	})
 }
 
+func TestGenerateRequestID(t *testing.T) {
+	t.Run("generates valid request ID", func(t *testing.T) {
+		requestID := GenerateRequestID()
+
+		assert.NotEmpty(t, requestID, "Generated request ID should not be empty")
+
+		// Verify it's valid hex encoding
+		decoded, err := hex.DecodeString(requestID)
+		assert.NoError(t, err, "Request ID should be valid hex encoding")
+		assert.NotEmpty(t, decoded, "Decoded request ID should not be empty")
+	})
+
+	t.Run("generates unique request IDs", func(t *testing.T) {
+		requestID1 := GenerateRequestID()
+		requestID2 := GenerateRequestID()
+
+		assert.NotEqual(t, requestID1, requestID2, "Two consecutive request IDs should be different")
+	})
+
+	t.Run("generates request IDs of consistent length", func(t *testing.T) {
+		// RequestIDByteSize is 16 bytes, hex encoded should be 32 characters
+		requestID := GenerateRequestID()
+		// Allow some flexibility for the fallback case, but normal case should be 32
+		assert.GreaterOrEqual(t, len(requestID), 16, "Request ID should be at least 16 characters")
+	})
+}
+
 // Benchmark for API key hashing
 func BenchmarkHashAPIKey(b *testing.B) {
 	apiKey := "test-key-for-benchmarking-12345"
@@ -132,5 +160,12 @@ func BenchmarkHashAPIKey(b *testing.B) {
 func BenchmarkGenerateSecretToken(b *testing.B) {
 	for b.Loop() {
 		_, _ = GenerateSecretToken()
+	}
+}
+
+// Benchmark for request ID generation
+func BenchmarkGenerateRequestID(b *testing.B) {
+	for b.Loop() {
+		_ = GenerateRequestID()
 	}
 }


### PR DESCRIPTION
Move `generateRequestID()` from `middleware.go` to `auth.go` to consolidate crypto/auth-related utility functions.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ee6fc81-d387-497e-b67c-b8983ce40344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6ee6fc81-d387-497e-b67c-b8983ce40344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

