### PR TITLE
Trim secret details from create/update responses

### DIFF
--- a/internal/api/secrets.go
+++ b/internal/api/secrets.go
@@ -27,9 +27,9 @@ type CreateSecretRequest struct {
 }
 
 // CreateSecretResponse represents the response after creating a secret
+// To avoid exposing secret data, only a success message is returned.
 type CreateSecretResponse struct {
-	Secret  *Secret `json:"secret"`
-	Message string  `json:"message"`
+	Message string `json:"message"`
 }
 
 // UpdateSecretRequest represents the request to update a secret (metadata and/or value)
@@ -43,9 +43,9 @@ type UpdateSecretRequest struct {
 }
 
 // UpdateSecretResponse represents the response after updating a secret
+// To avoid exposing secret data, only a success message is returned.
 type UpdateSecretResponse struct {
-	Secret  *Secret `json:"secret"`
-	Message string  `json:"message"`
+	Message string `json:"message"`
 }
 
 // GetSecretRequest represents the request to retrieve a secret

--- a/internal/app/main.go
+++ b/internal/app/main.go
@@ -91,9 +91,9 @@ func (s *Service) CreateSecret(
 	ctx context.Context,
 	req *api.CreateSecretRequest,
 	userEmail string,
-) (*api.Secret, error) {
+) error {
 	if s.secretsRepo == nil {
-		return nil, apperrors.ErrInternalError("secrets repository not available", fmt.Errorf("secretsRepo is nil"))
+		return apperrors.ErrInternalError("secrets repository not available", fmt.Errorf("secretsRepo is nil"))
 	}
 	secret := &api.Secret{
 		Name:        req.Name,
@@ -103,9 +103,9 @@ func (s *Service) CreateSecret(
 		CreatedBy:   userEmail,
 	}
 	if err := s.secretsRepo.CreateSecret(ctx, secret); err != nil {
-		return nil, err
+		return err
 	}
-	return s.secretsRepo.GetSecret(ctx, req.Name, true)
+	return nil
 }
 
 // GetSecret retrieves a secret's metadata and value by name.
@@ -130,9 +130,9 @@ func (s *Service) UpdateSecret(
 	name string,
 	req *api.UpdateSecretRequest,
 	userEmail string,
-) (*api.Secret, error) {
+) error {
 	if s.secretsRepo == nil {
-		return nil, apperrors.ErrInternalError("secrets repository not available", fmt.Errorf("secretsRepo is nil"))
+		return apperrors.ErrInternalError("secrets repository not available", fmt.Errorf("secretsRepo is nil"))
 	}
 	secret := &api.Secret{
 		Name:        name,
@@ -142,9 +142,9 @@ func (s *Service) UpdateSecret(
 		UpdatedBy:   userEmail,
 	}
 	if err := s.secretsRepo.UpdateSecret(ctx, secret); err != nil {
-		return nil, err
+		return err
 	}
-	return s.secretsRepo.GetSecret(ctx, name, true)
+	return nil
 }
 
 // DeleteSecret deletes a secret and its value.

--- a/internal/server/handlers_secrets.go
+++ b/internal/server/handlers_secrets.go
@@ -25,15 +25,13 @@ func (r *Router) handleCreateSecret(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	secret, err := r.svc.CreateSecret(req.Context(), &createReq, user.Email)
-	if err != nil {
+	if err := r.svc.CreateSecret(req.Context(), &createReq, user.Email); err != nil {
 		handleServiceError(w, err)
 		return
 	}
 
 	w.WriteHeader(http.StatusCreated)
 	_ = json.NewEncoder(w).Encode(api.CreateSecretResponse{
-		Secret:  secret,
 		Message: "Secret created successfully",
 	})
 }
@@ -106,15 +104,13 @@ func (r *Router) handleUpdateSecret(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	secret, err := r.svc.UpdateSecret(req.Context(), name, &updateReq, user.Email)
-	if err != nil {
+	if err := r.svc.UpdateSecret(req.Context(), name, &updateReq, user.Email); err != nil {
 		handleServiceError(w, err)
 		return
 	}
 
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(api.UpdateSecretResponse{
-		Secret:  secret,
 		Message: "Secret updated successfully",
 	})
 }


### PR DESCRIPTION
Remove `api.Secret` from `CreateSecretResponse` and `UpdateSecretResponse` to prevent echoing secret data back to clients.

---
<a href="https://cursor.com/background-agent?bcId=bc-21139656-3de0-429c-9537-28f2c93117a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-21139656-3de0-429c-9537-28f2c93117a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

