### PR TITLE
Increase code unit test coverage

### DIFF
--- a/internal/api/executions_test.go
+++ b/internal/api/executions_test.go
@@ -1,0 +1,201 @@
+// Package api defines the API types and structures used across runvoy.
+package api
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecutionRequestJSON(t *testing.T) {
+	t.Run("marshal and unmarshal with all fields", func(t *testing.T) {
+		req := ExecutionRequest{
+			Command: "echo hello",
+			Image:   "alpine:latest",
+			Env:     map[string]string{"KEY": "value"},
+			Timeout: 300,
+			Secrets: []string{"secret1", "secret2"},
+			GitRepo: "https://github.com/user/repo.git",
+			GitRef:  "main",
+			GitPath: ".",
+		}
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var unmarshaled ExecutionRequest
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, req.Command, unmarshaled.Command)
+		assert.Equal(t, req.Image, unmarshaled.Image)
+		assert.Equal(t, req.Env, unmarshaled.Env)
+		assert.Equal(t, req.Timeout, unmarshaled.Timeout)
+		assert.Equal(t, req.Secrets, unmarshaled.Secrets)
+		assert.Equal(t, req.GitRepo, unmarshaled.GitRepo)
+		assert.Equal(t, req.GitRef, unmarshaled.GitRef)
+		assert.Equal(t, req.GitPath, unmarshaled.GitPath)
+	})
+
+	t.Run("omit empty optional fields", func(t *testing.T) {
+		req := ExecutionRequest{
+			Command: "echo hello",
+		}
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		// Optional fields should be omitted when empty
+		assert.NotContains(t, string(data), "image")
+		assert.NotContains(t, string(data), "env")
+		assert.NotContains(t, string(data), "timeout")
+	})
+}
+
+func TestExecutionResponseJSON(t *testing.T) {
+	t.Run("marshal and unmarshal", func(t *testing.T) {
+		resp := ExecutionResponse{
+			ExecutionID: "exec-123",
+			LogURL:      "https://example.com/logs",
+			Status:      "running",
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var unmarshaled ExecutionResponse
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, resp.ExecutionID, unmarshaled.ExecutionID)
+		assert.Equal(t, resp.LogURL, unmarshaled.LogURL)
+		assert.Equal(t, resp.Status, unmarshaled.Status)
+	})
+}
+
+func TestExecutionStatusResponseJSON(t *testing.T) {
+	t.Run("marshal and unmarshal with completed execution", func(t *testing.T) {
+		now := time.Now()
+		exitCode := 0
+		resp := ExecutionStatusResponse{
+			ExecutionID: "exec-123",
+			Status:      "completed",
+			StartedAt:   now,
+			ExitCode:    &exitCode,
+			CompletedAt: &now,
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var unmarshaled ExecutionStatusResponse
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, resp.ExecutionID, unmarshaled.ExecutionID)
+		assert.Equal(t, resp.Status, unmarshaled.Status)
+		assert.NotNil(t, unmarshaled.ExitCode)
+		assert.Equal(t, *resp.ExitCode, *unmarshaled.ExitCode)
+		assert.NotNil(t, unmarshaled.CompletedAt)
+	})
+
+	t.Run("marshal and unmarshal running execution", func(t *testing.T) {
+		now := time.Now()
+		resp := ExecutionStatusResponse{
+			ExecutionID: "exec-123",
+			Status:      "running",
+			StartedAt:   now,
+			ExitCode:    nil,
+			CompletedAt: nil,
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var unmarshaled ExecutionStatusResponse
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, resp.ExecutionID, unmarshaled.ExecutionID)
+		assert.Equal(t, resp.Status, unmarshaled.Status)
+		assert.Nil(t, unmarshaled.CompletedAt)
+	})
+}
+
+func TestKillExecutionResponseJSON(t *testing.T) {
+	t.Run("marshal and unmarshal", func(t *testing.T) {
+		resp := KillExecutionResponse{
+			ExecutionID: "exec-123",
+			Message:     "Execution killed successfully",
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var unmarshaled KillExecutionResponse
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, resp.ExecutionID, unmarshaled.ExecutionID)
+		assert.Equal(t, resp.Message, unmarshaled.Message)
+	})
+}
+
+func TestExecutionJSON(t *testing.T) {
+	t.Run("marshal and unmarshal completed execution", func(t *testing.T) {
+		now := time.Now()
+		exec := Execution{
+			ExecutionID:     "exec-123",
+			UserEmail:       "user@example.com",
+			Command:         "echo hello",
+			StartedAt:       now,
+			CompletedAt:     &now,
+			Status:          "completed",
+			ExitCode:        0,
+			DurationSeconds: 5,
+			LogStreamName:   "stream-123",
+			RequestID:       "req-123",
+			ComputePlatform: "aws",
+		}
+
+		data, err := json.Marshal(exec)
+		require.NoError(t, err)
+
+		var unmarshaled Execution
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, exec.ExecutionID, unmarshaled.ExecutionID)
+		assert.Equal(t, exec.UserEmail, unmarshaled.UserEmail)
+		assert.Equal(t, exec.Command, unmarshaled.Command)
+		assert.Equal(t, exec.Status, unmarshaled.Status)
+		assert.Equal(t, exec.ExitCode, unmarshaled.ExitCode)
+		assert.NotNil(t, unmarshaled.CompletedAt)
+	})
+
+	t.Run("marshal and unmarshal running execution", func(t *testing.T) {
+		now := time.Now()
+		exec := Execution{
+			ExecutionID: "exec-123",
+			UserEmail:   "user@example.com",
+			Command:     "echo hello",
+			StartedAt:   now,
+			CompletedAt: nil,
+			Status:      "running",
+		}
+
+		data, err := json.Marshal(exec)
+		require.NoError(t, err)
+
+		var unmarshaled Execution
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, exec.ExecutionID, unmarshaled.ExecutionID)
+		assert.Equal(t, exec.Status, unmarshaled.Status)
+		assert.Nil(t, unmarshaled.CompletedAt)
+	})
+}

--- a/internal/api/images_test.go
+++ b/internal/api/images_test.go
@@ -1,0 +1,185 @@
+// Package api defines the API types and structures used across runvoy.
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterImageRequestJSON(t *testing.T) {
+	t.Run("marshal and unmarshal with is_default", func(t *testing.T) {
+		isDefault := true
+		req := RegisterImageRequest{
+			Image:     "alpine:latest",
+			IsDefault: &isDefault,
+		}
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var unmarshaled RegisterImageRequest
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, req.Image, unmarshaled.Image)
+		assert.NotNil(t, unmarshaled.IsDefault)
+		assert.Equal(t, *req.IsDefault, *unmarshaled.IsDefault)
+	})
+
+	t.Run("marshal and unmarshal without is_default", func(t *testing.T) {
+		req := RegisterImageRequest{
+			Image: "alpine:latest",
+		}
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var unmarshaled RegisterImageRequest
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, req.Image, unmarshaled.Image)
+		assert.Nil(t, unmarshaled.IsDefault)
+	})
+}
+
+func TestRegisterImageResponseJSON(t *testing.T) {
+	t.Run("marshal and unmarshal", func(t *testing.T) {
+		resp := RegisterImageResponse{
+			Image:   "alpine:latest",
+			Message: "Image registered successfully",
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var unmarshaled RegisterImageResponse
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, resp.Image, unmarshaled.Image)
+		assert.Equal(t, resp.Message, unmarshaled.Message)
+	})
+}
+
+func TestRemoveImageRequestJSON(t *testing.T) {
+	t.Run("marshal and unmarshal", func(t *testing.T) {
+		req := RemoveImageRequest{
+			Image: "alpine:latest",
+		}
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var unmarshaled RemoveImageRequest
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, req.Image, unmarshaled.Image)
+	})
+}
+
+func TestRemoveImageResponseJSON(t *testing.T) {
+	t.Run("marshal and unmarshal", func(t *testing.T) {
+		resp := RemoveImageResponse{
+			Image:   "alpine:latest",
+			Message: "Image removed successfully",
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var unmarshaled RemoveImageResponse
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, resp.Image, unmarshaled.Image)
+		assert.Equal(t, resp.Message, unmarshaled.Message)
+	})
+}
+
+func TestImageInfoJSON(t *testing.T) {
+	t.Run("marshal and unmarshal with all fields", func(t *testing.T) {
+		isDefault := true
+		info := ImageInfo{
+			Image:              "alpine:latest",
+			TaskDefinitionARN:  "arn:aws:ecs:us-east-1:123456789012:task-definition/runvoy:1",
+			TaskDefinitionName: "runvoy",
+			IsDefault:          &isDefault,
+		}
+
+		data, err := json.Marshal(info)
+		require.NoError(t, err)
+
+		var unmarshaled ImageInfo
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, info.Image, unmarshaled.Image)
+		assert.Equal(t, info.TaskDefinitionARN, unmarshaled.TaskDefinitionARN)
+		assert.Equal(t, info.TaskDefinitionName, unmarshaled.TaskDefinitionName)
+		assert.NotNil(t, unmarshaled.IsDefault)
+		assert.Equal(t, *info.IsDefault, *unmarshaled.IsDefault)
+	})
+
+	t.Run("omit optional fields", func(t *testing.T) {
+		info := ImageInfo{
+			Image: "alpine:latest",
+		}
+
+		data, err := json.Marshal(info)
+		require.NoError(t, err)
+
+		jsonStr := string(data)
+		assert.Contains(t, jsonStr, "alpine:latest")
+		assert.NotContains(t, jsonStr, "task_definition_arn")
+		assert.NotContains(t, jsonStr, "is_default")
+	})
+}
+
+func TestListImagesResponseJSON(t *testing.T) {
+	t.Run("marshal and unmarshal", func(t *testing.T) {
+		isDefault := true
+		resp := ListImagesResponse{
+			Images: []ImageInfo{
+				{
+					Image:     "alpine:latest",
+					IsDefault: &isDefault,
+				},
+				{
+					Image: "ubuntu:20.04",
+				},
+			},
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var unmarshaled ListImagesResponse
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Len(t, unmarshaled.Images, 2)
+		assert.Equal(t, resp.Images[0].Image, unmarshaled.Images[0].Image)
+		assert.NotNil(t, unmarshaled.Images[0].IsDefault)
+		assert.Nil(t, unmarshaled.Images[1].IsDefault)
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		resp := ListImagesResponse{
+			Images: []ImageInfo{},
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var unmarshaled ListImagesResponse
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Empty(t, unmarshaled.Images)
+	})
+}

--- a/internal/api/logs_test.go
+++ b/internal/api/logs_test.go
@@ -1,0 +1,123 @@
+// Package api defines the API types and structures used across runvoy.
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogEventJSON(t *testing.T) {
+	t.Run("marshal and unmarshal", func(t *testing.T) {
+		event := LogEvent{
+			Timestamp: 1234567890,
+			Message:   "Test log message",
+		}
+
+		data, err := json.Marshal(event)
+		require.NoError(t, err)
+
+		var unmarshaled LogEvent
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, event.Timestamp, unmarshaled.Timestamp)
+		assert.Equal(t, event.Message, unmarshaled.Message)
+	})
+
+	t.Run("handle empty message", func(t *testing.T) {
+		event := LogEvent{
+			Timestamp: 1234567890,
+			Message:   "",
+		}
+
+		data, err := json.Marshal(event)
+		require.NoError(t, err)
+
+		var unmarshaled LogEvent
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, event.Timestamp, unmarshaled.Timestamp)
+		assert.Empty(t, unmarshaled.Message)
+	})
+}
+
+func TestLogsResponseJSON(t *testing.T) {
+	t.Run("marshal and unmarshal with WebSocketURL", func(t *testing.T) {
+		resp := LogsResponse{
+			ExecutionID: "exec-123",
+			Events: []LogEvent{
+				{Timestamp: 1000, Message: "Log 1"},
+				{Timestamp: 2000, Message: "Log 2"},
+			},
+			Status:       "RUNNING",
+			WebSocketURL: "wss://example.com/ws",
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var unmarshaled LogsResponse
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, resp.ExecutionID, unmarshaled.ExecutionID)
+		assert.Len(t, unmarshaled.Events, 2)
+		assert.Equal(t, resp.Status, unmarshaled.Status)
+		assert.Equal(t, resp.WebSocketURL, unmarshaled.WebSocketURL)
+	})
+
+	t.Run("omit WebSocketURL when empty", func(t *testing.T) {
+		resp := LogsResponse{
+			ExecutionID: "exec-123",
+			Events:      []LogEvent{},
+			Status:      "SUCCEEDED",
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		jsonStr := string(data)
+		assert.NotContains(t, jsonStr, "websocket_url")
+	})
+
+	t.Run("handle empty events", func(t *testing.T) {
+		resp := LogsResponse{
+			ExecutionID: "exec-123",
+			Events:      []LogEvent{},
+			Status:      "SUCCEEDED",
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var unmarshaled LogsResponse
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, resp.ExecutionID, unmarshaled.ExecutionID)
+		assert.Empty(t, unmarshaled.Events)
+		assert.Equal(t, resp.Status, unmarshaled.Status)
+	})
+
+	t.Run("handle nil events", func(t *testing.T) {
+		resp := LogsResponse{
+			ExecutionID: "exec-123",
+			Events:      nil,
+			Status:      "SUCCEEDED",
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var unmarshaled LogsResponse
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, resp.ExecutionID, unmarshaled.ExecutionID)
+		assert.Nil(t, unmarshaled.Events)
+	})
+}

--- a/internal/api/secrets_test.go
+++ b/internal/api/secrets_test.go
@@ -1,0 +1,307 @@
+// Package api defines the API types and structures used across runvoy.
+package api
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecretJSON(t *testing.T) {
+	t.Run("marshal and unmarshal with value", func(t *testing.T) {
+		now := time.Now()
+		secret := Secret{
+			Name:        "db-password",
+			KeyName:     "DATABASE_PASSWORD",
+			Description: "Database password for production",
+			Value:       "super-secret",
+			CreatedBy:   "admin@example.com",
+			CreatedAt:   now,
+			UpdatedAt:   now,
+			UpdatedBy:   "admin@example.com",
+		}
+
+		data, err := json.Marshal(secret)
+		require.NoError(t, err)
+
+		var unmarshaled Secret
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, secret.Name, unmarshaled.Name)
+		assert.Equal(t, secret.KeyName, unmarshaled.KeyName)
+		assert.Equal(t, secret.Description, unmarshaled.Description)
+		assert.Equal(t, secret.Value, unmarshaled.Value)
+		assert.Equal(t, secret.CreatedBy, unmarshaled.CreatedBy)
+		assert.Equal(t, secret.UpdatedBy, unmarshaled.UpdatedBy)
+	})
+
+	t.Run("omit optional fields", func(t *testing.T) {
+		now := time.Now()
+		secret := Secret{
+			Name:      "db-password",
+			KeyName:   "DATABASE_PASSWORD",
+			CreatedBy: "admin@example.com",
+			CreatedAt: now,
+			UpdatedAt: now,
+			UpdatedBy: "admin@example.com",
+		}
+
+		data, err := json.Marshal(secret)
+		require.NoError(t, err)
+
+		// Description and Value should be omitted when empty
+		jsonStr := string(data)
+		assert.NotContains(t, jsonStr, "description")
+		assert.NotContains(t, jsonStr, "value")
+	})
+}
+
+func TestCreateSecretRequestJSON(t *testing.T) {
+	t.Run("marshal and unmarshal with all fields", func(t *testing.T) {
+		req := CreateSecretRequest{
+			Name:        "db-password",
+			KeyName:     "DATABASE_PASSWORD",
+			Description: "Database password",
+			Value:       "super-secret",
+		}
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var unmarshaled CreateSecretRequest
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, req.Name, unmarshaled.Name)
+		assert.Equal(t, req.KeyName, unmarshaled.KeyName)
+		assert.Equal(t, req.Description, unmarshaled.Description)
+		assert.Equal(t, req.Value, unmarshaled.Value)
+	})
+
+	t.Run("omit optional description", func(t *testing.T) {
+		req := CreateSecretRequest{
+			Name:    "db-password",
+			KeyName: "DATABASE_PASSWORD",
+			Value:   "super-secret",
+		}
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var unmarshaled CreateSecretRequest
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, req.Name, unmarshaled.Name)
+		assert.Empty(t, unmarshaled.Description)
+	})
+}
+
+func TestCreateSecretResponseJSON(t *testing.T) {
+	t.Run("marshal and unmarshal", func(t *testing.T) {
+		resp := CreateSecretResponse{
+			Message: "Secret created successfully",
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var unmarshaled CreateSecretResponse
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, resp.Message, unmarshaled.Message)
+	})
+}
+
+func TestUpdateSecretRequestJSON(t *testing.T) {
+	t.Run("marshal and unmarshal with all fields", func(t *testing.T) {
+		req := UpdateSecretRequest{
+			Description: "Updated description",
+			KeyName:     "UPDATED_KEY",
+			Value:       "new-value",
+		}
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var unmarshaled UpdateSecretRequest
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, req.Description, unmarshaled.Description)
+		assert.Equal(t, req.KeyName, unmarshaled.KeyName)
+		assert.Equal(t, req.Value, unmarshaled.Value)
+	})
+
+	t.Run("omit optional fields", func(t *testing.T) {
+		req := UpdateSecretRequest{
+			Description: "Updated description",
+		}
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		jsonStr := string(data)
+		assert.Contains(t, jsonStr, "description")
+		assert.NotContains(t, jsonStr, "key_name")
+		assert.NotContains(t, jsonStr, "value")
+	})
+}
+
+func TestUpdateSecretResponseJSON(t *testing.T) {
+	t.Run("marshal and unmarshal", func(t *testing.T) {
+		resp := UpdateSecretResponse{
+			Message: "Secret updated successfully",
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var unmarshaled UpdateSecretResponse
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, resp.Message, unmarshaled.Message)
+	})
+}
+
+func TestGetSecretRequestJSON(t *testing.T) {
+	t.Run("marshal and unmarshal", func(t *testing.T) {
+		req := GetSecretRequest{
+			Name: "db-password",
+		}
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var unmarshaled GetSecretRequest
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, req.Name, unmarshaled.Name)
+	})
+}
+
+func TestGetSecretResponseJSON(t *testing.T) {
+	t.Run("marshal and unmarshal", func(t *testing.T) {
+		now := time.Now()
+		resp := GetSecretResponse{
+			Secret: &Secret{
+				Name:      "db-password",
+				KeyName:   "DATABASE_PASSWORD",
+				Value:     "super-secret",
+				CreatedBy: "admin@example.com",
+				CreatedAt: now,
+				UpdatedAt: now,
+				UpdatedBy: "admin@example.com",
+			},
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var unmarshaled GetSecretResponse
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.NotNil(t, unmarshaled.Secret)
+		assert.Equal(t, resp.Secret.Name, unmarshaled.Secret.Name)
+		assert.Equal(t, resp.Secret.Value, unmarshaled.Secret.Value)
+	})
+}
+
+func TestListSecretsRequestJSON(t *testing.T) {
+	t.Run("marshal and unmarshal with filter", func(t *testing.T) {
+		req := ListSecretsRequest{
+			CreatedBy: "user@example.com",
+		}
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var unmarshaled ListSecretsRequest
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, req.CreatedBy, unmarshaled.CreatedBy)
+	})
+}
+
+func TestListSecretsResponseJSON(t *testing.T) {
+	t.Run("marshal and unmarshal", func(t *testing.T) {
+		now := time.Now()
+		resp := ListSecretsResponse{
+			Secrets: []*Secret{
+				{
+					Name:      "secret1",
+					KeyName:   "KEY1",
+					CreatedBy: "user@example.com",
+					CreatedAt: now,
+					UpdatedAt: now,
+					UpdatedBy: "user@example.com",
+				},
+				{
+					Name:      "secret2",
+					KeyName:   "KEY2",
+					CreatedBy: "user@example.com",
+					CreatedAt: now,
+					UpdatedAt: now,
+					UpdatedBy: "user@example.com",
+				},
+			},
+			Total: 2,
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var unmarshaled ListSecretsResponse
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Len(t, unmarshaled.Secrets, 2)
+		assert.Equal(t, resp.Total, unmarshaled.Total)
+		assert.Equal(t, resp.Secrets[0].Name, unmarshaled.Secrets[0].Name)
+	})
+}
+
+func TestDeleteSecretRequestJSON(t *testing.T) {
+	t.Run("marshal and unmarshal", func(t *testing.T) {
+		req := DeleteSecretRequest{
+			Name: "db-password",
+		}
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var unmarshaled DeleteSecretRequest
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, req.Name, unmarshaled.Name)
+	})
+}
+
+func TestDeleteSecretResponseJSON(t *testing.T) {
+	t.Run("marshal and unmarshal", func(t *testing.T) {
+		resp := DeleteSecretResponse{
+			Name:    "db-password",
+			Message: "Secret deleted successfully",
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var unmarshaled DeleteSecretResponse
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, resp.Name, unmarshaled.Name)
+		assert.Equal(t, resp.Message, unmarshaled.Message)
+	})
+}

--- a/internal/api/types_test.go
+++ b/internal/api/types_test.go
@@ -1,0 +1,63 @@
+// Package api defines the API types and structures used across runvoy.
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorResponseJSON(t *testing.T) {
+	t.Run("marshal and unmarshal", func(t *testing.T) {
+		resp := ErrorResponse{
+			Error:   "test error",
+			Code:    "TEST_CODE",
+			Details: "detailed information",
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var unmarshaled ErrorResponse
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, resp.Error, unmarshaled.Error)
+		assert.Equal(t, resp.Code, unmarshaled.Code)
+		assert.Equal(t, resp.Details, unmarshaled.Details)
+	})
+
+	t.Run("omit empty fields", func(t *testing.T) {
+		resp := ErrorResponse{
+			Error: "test error",
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		// Code and Details should be omitted when empty
+		assert.NotContains(t, string(data), "code")
+		assert.NotContains(t, string(data), "details")
+	})
+}
+
+func TestHealthResponseJSON(t *testing.T) {
+	t.Run("marshal and unmarshal", func(t *testing.T) {
+		resp := HealthResponse{
+			Status:  "healthy",
+			Version: "1.0.0",
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var unmarshaled HealthResponse
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, resp.Status, unmarshaled.Status)
+		assert.Equal(t, resp.Version, unmarshaled.Version)
+	})
+}

--- a/internal/api/users_test.go
+++ b/internal/api/users_test.go
@@ -1,0 +1,257 @@
+// Package api defines the API types and structures used across runvoy.
+package api
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserJSON(t *testing.T) {
+	t.Run("marshal and unmarshal with all fields", func(t *testing.T) {
+		now := time.Now()
+		user := User{
+			Email:     "user@example.com",
+			APIKey:    "key-123",
+			CreatedAt: now,
+			Revoked:   false,
+			LastUsed:  &now,
+		}
+
+		data, err := json.Marshal(user)
+		require.NoError(t, err)
+
+		var unmarshaled User
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, user.Email, unmarshaled.Email)
+		assert.Equal(t, user.APIKey, unmarshaled.APIKey)
+		assert.Equal(t, user.Revoked, unmarshaled.Revoked)
+		assert.NotNil(t, unmarshaled.LastUsed)
+	})
+
+	t.Run("omit empty optional fields", func(t *testing.T) {
+		now := time.Now()
+		user := User{
+			Email:     "user@example.com",
+			CreatedAt: now,
+			Revoked:   false,
+		}
+
+		data, err := json.Marshal(user)
+		require.NoError(t, err)
+
+		// APIKey and LastUsed should be omitted when empty
+		jsonStr := string(data)
+		assert.NotContains(t, jsonStr, "api_key")
+		assert.NotContains(t, jsonStr, "last_used")
+	})
+}
+
+func TestCreateUserRequestJSON(t *testing.T) {
+	t.Run("marshal and unmarshal with API key", func(t *testing.T) {
+		req := CreateUserRequest{
+			Email:  "user@example.com",
+			APIKey: "custom-key",
+		}
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var unmarshaled CreateUserRequest
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, req.Email, unmarshaled.Email)
+		assert.Equal(t, req.APIKey, unmarshaled.APIKey)
+	})
+
+	t.Run("marshal and unmarshal without API key", func(t *testing.T) {
+		req := CreateUserRequest{
+			Email: "user@example.com",
+		}
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var unmarshaled CreateUserRequest
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, req.Email, unmarshaled.Email)
+		assert.Empty(t, unmarshaled.APIKey)
+	})
+}
+
+func TestCreateUserResponseJSON(t *testing.T) {
+	t.Run("marshal and unmarshal", func(t *testing.T) {
+		now := time.Now()
+		resp := CreateUserResponse{
+			User: &User{
+				Email:     "user@example.com",
+				CreatedAt: now,
+				Revoked:   false,
+			},
+			ClaimToken: "token-123",
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var unmarshaled CreateUserResponse
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.NotNil(t, unmarshaled.User)
+		assert.Equal(t, resp.User.Email, unmarshaled.User.Email)
+		assert.Equal(t, resp.ClaimToken, unmarshaled.ClaimToken)
+	})
+}
+
+func TestPendingAPIKeyJSON(t *testing.T) {
+	t.Run("marshal and unmarshal viewed key", func(t *testing.T) {
+		now := time.Now()
+		key := PendingAPIKey{
+			SecretToken:  "token-123",
+			APIKey:       "key-123",
+			UserEmail:    "user@example.com",
+			CreatedBy:    "admin@example.com",
+			CreatedAt:    now,
+			ExpiresAt:    now.Unix() + 3600,
+			Viewed:       true,
+			ViewedAt:     &now,
+			ViewedFromIP: "192.168.1.1",
+		}
+
+		data, err := json.Marshal(key)
+		require.NoError(t, err)
+
+		var unmarshaled PendingAPIKey
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, key.SecretToken, unmarshaled.SecretToken)
+		assert.Equal(t, key.APIKey, unmarshaled.APIKey)
+		assert.Equal(t, key.UserEmail, unmarshaled.UserEmail)
+		assert.Equal(t, key.CreatedBy, unmarshaled.CreatedBy)
+		assert.Equal(t, key.Viewed, unmarshaled.Viewed)
+		assert.NotNil(t, unmarshaled.ViewedAt)
+		assert.Equal(t, key.ViewedFromIP, unmarshaled.ViewedFromIP)
+	})
+
+	t.Run("marshal and unmarshal unviewed key", func(t *testing.T) {
+		now := time.Now()
+		key := PendingAPIKey{
+			SecretToken: "token-123",
+			APIKey:      "key-123",
+			UserEmail:   "user@example.com",
+			CreatedBy:   "admin@example.com",
+			CreatedAt:   now,
+			ExpiresAt:   now.Unix() + 3600,
+			Viewed:      false,
+		}
+
+		data, err := json.Marshal(key)
+		require.NoError(t, err)
+
+		var unmarshaled PendingAPIKey
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, key.SecretToken, unmarshaled.SecretToken)
+		assert.Equal(t, key.Viewed, unmarshaled.Viewed)
+		assert.Nil(t, unmarshaled.ViewedAt)
+	})
+}
+
+func TestClaimAPIKeyResponseJSON(t *testing.T) {
+	t.Run("marshal and unmarshal", func(t *testing.T) {
+		resp := ClaimAPIKeyResponse{
+			APIKey:    "key-123",
+			UserEmail: "user@example.com",
+			Message:   "API key claimed successfully",
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var unmarshaled ClaimAPIKeyResponse
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, resp.APIKey, unmarshaled.APIKey)
+		assert.Equal(t, resp.UserEmail, unmarshaled.UserEmail)
+		assert.Equal(t, resp.Message, unmarshaled.Message)
+	})
+}
+
+func TestRevokeUserRequestJSON(t *testing.T) {
+	t.Run("marshal and unmarshal", func(t *testing.T) {
+		req := RevokeUserRequest{
+			Email: "user@example.com",
+		}
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var unmarshaled RevokeUserRequest
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, req.Email, unmarshaled.Email)
+	})
+}
+
+func TestRevokeUserResponseJSON(t *testing.T) {
+	t.Run("marshal and unmarshal", func(t *testing.T) {
+		resp := RevokeUserResponse{
+			Message: "User revoked successfully",
+			Email:   "user@example.com",
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var unmarshaled RevokeUserResponse
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, resp.Message, unmarshaled.Message)
+		assert.Equal(t, resp.Email, unmarshaled.Email)
+	})
+}
+
+func TestListUsersResponseJSON(t *testing.T) {
+	t.Run("marshal and unmarshal", func(t *testing.T) {
+		now := time.Now()
+		resp := ListUsersResponse{
+			Users: []*User{
+				{
+					Email:     "user1@example.com",
+					CreatedAt: now,
+					Revoked:   false,
+				},
+				{
+					Email:     "user2@example.com",
+					CreatedAt: now,
+					Revoked:   true,
+				},
+			},
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var unmarshaled ListUsersResponse
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Len(t, unmarshaled.Users, 2)
+		assert.Equal(t, resp.Users[0].Email, unmarshaled.Users[0].Email)
+		assert.Equal(t, resp.Users[1].Email, unmarshaled.Users[1].Email)
+	})
+}

--- a/internal/api/websocket_test.go
+++ b/internal/api/websocket_test.go
@@ -1,0 +1,173 @@
+// Package api defines the API types and structures used across runvoy.
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebSocketConnectionJSON(t *testing.T) {
+	t.Run("marshal and unmarshal with all fields", func(t *testing.T) {
+		conn := WebSocketConnection{
+			ConnectionID:         "conn-123",
+			ExecutionID:          "exec-456",
+			Functionality:        "logs",
+			ExpiresAt:            1234567890,
+			ClientIP:             "192.168.1.1",
+			Token:                "token-abc",
+			UserEmail:            "user@example.com",
+			TokenRequestClientIP: "192.168.1.2",
+		}
+
+		data, err := json.Marshal(conn)
+		require.NoError(t, err)
+
+		var unmarshaled WebSocketConnection
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, conn.ConnectionID, unmarshaled.ConnectionID)
+		assert.Equal(t, conn.ExecutionID, unmarshaled.ExecutionID)
+		assert.Equal(t, conn.Functionality, unmarshaled.Functionality)
+		assert.Equal(t, conn.ExpiresAt, unmarshaled.ExpiresAt)
+		assert.Equal(t, conn.ClientIP, unmarshaled.ClientIP)
+		assert.Equal(t, conn.Token, unmarshaled.Token)
+		assert.Equal(t, conn.UserEmail, unmarshaled.UserEmail)
+		assert.Equal(t, conn.TokenRequestClientIP, unmarshaled.TokenRequestClientIP)
+	})
+
+	t.Run("omit optional fields", func(t *testing.T) {
+		conn := WebSocketConnection{
+			ConnectionID:  "conn-123",
+			ExecutionID:   "exec-456",
+			Functionality: "logs",
+			ExpiresAt:     1234567890,
+		}
+
+		data, err := json.Marshal(conn)
+		require.NoError(t, err)
+
+		jsonStr := string(data)
+		assert.NotContains(t, jsonStr, "client_ip")
+		assert.NotContains(t, jsonStr, "token")
+		assert.NotContains(t, jsonStr, "user_email")
+	})
+}
+
+func TestWebSocketTokenJSON(t *testing.T) {
+	t.Run("marshal and unmarshal with all fields", func(t *testing.T) {
+		token := WebSocketToken{
+			Token:       "token-123",
+			ExecutionID: "exec-456",
+			UserEmail:   "user@example.com",
+			ClientIP:    "192.168.1.1",
+			ExpiresAt:   1234567890,
+			CreatedAt:   1234567000,
+		}
+
+		data, err := json.Marshal(token)
+		require.NoError(t, err)
+
+		var unmarshaled WebSocketToken
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, token.Token, unmarshaled.Token)
+		assert.Equal(t, token.ExecutionID, unmarshaled.ExecutionID)
+		assert.Equal(t, token.UserEmail, unmarshaled.UserEmail)
+		assert.Equal(t, token.ClientIP, unmarshaled.ClientIP)
+		assert.Equal(t, token.ExpiresAt, unmarshaled.ExpiresAt)
+		assert.Equal(t, token.CreatedAt, unmarshaled.CreatedAt)
+	})
+
+	t.Run("omit optional fields", func(t *testing.T) {
+		token := WebSocketToken{
+			Token:       "token-123",
+			ExecutionID: "exec-456",
+			ExpiresAt:   1234567890,
+			CreatedAt:   1234567000,
+		}
+
+		data, err := json.Marshal(token)
+		require.NoError(t, err)
+
+		jsonStr := string(data)
+		assert.NotContains(t, jsonStr, "user_email")
+		assert.NotContains(t, jsonStr, "client_ip")
+	})
+}
+
+func TestWebSocketMessageTypes(t *testing.T) {
+	t.Run("message type constants", func(t *testing.T) {
+		assert.Equal(t, WebSocketMessageType("log"), WebSocketMessageTypeLog)
+		assert.Equal(t, WebSocketMessageType("disconnect"), WebSocketMessageTypeDisconnect)
+	})
+
+	t.Run("disconnect reason constants", func(t *testing.T) {
+		assert.Equal(t, WebSocketDisconnectReason("execution_completed"), WebSocketDisconnectReasonExecutionCompleted)
+	})
+}
+
+func TestWebSocketMessageJSON(t *testing.T) {
+	t.Run("marshal and unmarshal log message", func(t *testing.T) {
+		timestamp := int64(1234567890)
+		message := "Test log message"
+		msg := WebSocketMessage{
+			Type:      WebSocketMessageTypeLog,
+			Message:   &message,
+			Timestamp: &timestamp,
+		}
+
+		data, err := json.Marshal(msg)
+		require.NoError(t, err)
+
+		var unmarshaled WebSocketMessage
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, msg.Type, unmarshaled.Type)
+		require.NotNil(t, unmarshaled.Message)
+		assert.Equal(t, *msg.Message, *unmarshaled.Message)
+		require.NotNil(t, unmarshaled.Timestamp)
+		assert.Equal(t, *msg.Timestamp, *unmarshaled.Timestamp)
+		assert.Nil(t, unmarshaled.Reason)
+	})
+
+	t.Run("marshal and unmarshal disconnect message", func(t *testing.T) {
+		reason := WebSocketDisconnectReasonExecutionCompleted
+		msg := WebSocketMessage{
+			Type:   WebSocketMessageTypeDisconnect,
+			Reason: &reason,
+		}
+
+		data, err := json.Marshal(msg)
+		require.NoError(t, err)
+
+		var unmarshaled WebSocketMessage
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, msg.Type, unmarshaled.Type)
+		require.NotNil(t, unmarshaled.Reason)
+		assert.Equal(t, *msg.Reason, *unmarshaled.Reason)
+		assert.Nil(t, unmarshaled.Message)
+		assert.Nil(t, unmarshaled.Timestamp)
+	})
+
+	t.Run("omit optional fields", func(t *testing.T) {
+		msg := WebSocketMessage{
+			Type: WebSocketMessageTypeLog,
+		}
+
+		data, err := json.Marshal(msg)
+		require.NoError(t, err)
+
+		jsonStr := string(data)
+		assert.NotContains(t, jsonStr, "reason")
+		assert.NotContains(t, jsonStr, "message")
+		assert.NotContains(t, jsonStr, "timestamp")
+	})
+}

--- a/internal/app/events/backend_test.go
+++ b/internal/app/events/backend_test.go
@@ -1,0 +1,90 @@
+// Package events provides event processing interfaces and utilities.
+package events
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebSocketResponseJSON(t *testing.T) {
+	t.Run("marshal and unmarshal with all fields", func(t *testing.T) {
+		resp := WebSocketResponse{
+			StatusCode: 200,
+			Headers: map[string]string{
+				"Content-Type": "application/json",
+				"X-Custom":     "value",
+			},
+			Body: `{"message": "success"}`,
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var unmarshaled WebSocketResponse
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, resp.StatusCode, unmarshaled.StatusCode)
+		assert.Equal(t, resp.Headers, unmarshaled.Headers)
+		assert.Equal(t, resp.Body, unmarshaled.Body)
+	})
+
+	t.Run("marshal and unmarshal with minimal fields", func(t *testing.T) {
+		resp := WebSocketResponse{
+			StatusCode: 404,
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var unmarshaled WebSocketResponse
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, resp.StatusCode, unmarshaled.StatusCode)
+		assert.Nil(t, unmarshaled.Headers)
+		assert.Empty(t, unmarshaled.Body)
+	})
+
+	t.Run("handles different status codes", func(t *testing.T) {
+		testCases := []int{200, 201, 400, 401, 403, 404, 500, 502, 503}
+
+		for _, statusCode := range testCases {
+			resp := WebSocketResponse{
+				StatusCode: statusCode,
+				Body:       "test body",
+			}
+
+			data, err := json.Marshal(resp)
+			require.NoError(t, err)
+
+			var unmarshaled WebSocketResponse
+			err = json.Unmarshal(data, &unmarshaled)
+			require.NoError(t, err)
+
+			assert.Equal(t, statusCode, unmarshaled.StatusCode)
+		}
+	})
+
+	t.Run("handles empty headers map", func(t *testing.T) {
+		resp := WebSocketResponse{
+			StatusCode: 200,
+			Headers:    map[string]string{},
+			Body:       "test",
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var unmarshaled WebSocketResponse
+		err = json.Unmarshal(data, &unmarshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, resp.StatusCode, unmarshaled.StatusCode)
+		assert.NotNil(t, unmarshaled.Headers)
+		assert.Empty(t, unmarshaled.Headers)
+	})
+}

--- a/internal/config/aws/config_test.go
+++ b/internal/config/aws/config_test.go
@@ -1,0 +1,204 @@
+// Package aws contains AWS-specific configuration helpers for Runvoy services.
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeWebSocketEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "https protocol",
+			input:    "https://example.com",
+			expected: "example.com",
+		},
+		{
+			name:     "http protocol",
+			input:    "http://example.com",
+			expected: "example.com",
+		},
+		{
+			name:     "wss protocol",
+			input:    "wss://example.com",
+			expected: "example.com",
+		},
+		{
+			name:     "ws protocol",
+			input:    "ws://example.com",
+			expected: "example.com",
+		},
+		{
+			name:     "no protocol",
+			input:    "example.com",
+			expected: "example.com",
+		},
+		{
+			name:     "with path",
+			input:    "https://example.com/path",
+			expected: "example.com/path",
+		},
+		{
+			name:     "with whitespace",
+			input:    "  https://example.com  ",
+			expected: "example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NormalizeWebSocketEndpoint(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestValidateOrchestrator(t *testing.T) {
+	t.Run("nil config", func(t *testing.T) {
+		err := ValidateOrchestrator(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "AWS configuration is required")
+	})
+
+	t.Run("empty config", func(t *testing.T) {
+		cfg := &Config{}
+		err := ValidateOrchestrator(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be empty")
+	})
+
+	t.Run("missing APIKeysTable", func(t *testing.T) {
+		cfg := &Config{
+			ECSCluster:                "cluster",
+			ExecutionsTable:           "executions",
+			LogGroup:                  "logs",
+			SecurityGroup:             "sg",
+			Subnet1:                   "subnet1",
+			Subnet2:                   "subnet2",
+			WebSocketAPIEndpoint:      "wss://example.com",
+			WebSocketConnectionsTable: "connections",
+			WebSocketTokensTable:      "tokens",
+			SecretsMetadataTable:      "secrets",
+			SecretsPrefix:             "/runvoy",
+			SecretsKMSKeyARN:          "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012",
+		}
+		err := ValidateOrchestrator(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "APIKeysTable")
+	})
+
+	t.Run("missing ECSCluster", func(t *testing.T) {
+		cfg := &Config{
+			APIKeysTable:              "keys",
+			ExecutionsTable:           "executions",
+			LogGroup:                  "logs",
+			SecurityGroup:             "sg",
+			Subnet1:                   "subnet1",
+			Subnet2:                   "subnet2",
+			WebSocketAPIEndpoint:      "wss://example.com",
+			WebSocketConnectionsTable: "connections",
+			WebSocketTokensTable:      "tokens",
+			SecretsMetadataTable:      "secrets",
+			SecretsPrefix:             "/runvoy",
+			SecretsKMSKeyARN:          "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012",
+		}
+		err := ValidateOrchestrator(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ECSCluster")
+	})
+
+	t.Run("valid config", func(t *testing.T) {
+		cfg := &Config{
+			APIKeysTable:              "keys",
+			ECSCluster:                "cluster",
+			ExecutionsTable:           "executions",
+			LogGroup:                  "logs",
+			SecurityGroup:             "sg",
+			Subnet1:                   "subnet1",
+			Subnet2:                   "subnet2",
+			TaskDefinition:            "task-def",
+			TaskExecRoleARN:           "arn:aws:iam::123456789012:role/exec-role",
+			TaskRoleARN:               "arn:aws:iam::123456789012:role/task-role",
+			WebSocketAPIEndpoint:      "wss://example.com",
+			WebSocketConnectionsTable: "connections",
+			WebSocketTokensTable:      "tokens",
+			SecretsMetadataTable:      "secrets",
+			SecretsPrefix:             "/runvoy",
+			SecretsKMSKeyARN:          "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012",
+		}
+		err := ValidateOrchestrator(cfg)
+		assert.NoError(t, err)
+	})
+}
+
+func TestValidateEventProcessor(t *testing.T) {
+	t.Run("nil config", func(t *testing.T) {
+		err := ValidateEventProcessor(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "AWS configuration is required")
+	})
+
+	t.Run("empty config", func(t *testing.T) {
+		cfg := &Config{}
+		err := ValidateEventProcessor(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be empty")
+	})
+
+	t.Run("missing ECSCluster", func(t *testing.T) {
+		cfg := &Config{
+			ExecutionsTable:           "executions",
+			WebSocketAPIEndpoint:      "wss://example.com",
+			WebSocketConnectionsTable: "connections",
+			WebSocketTokensTable:      "tokens",
+		}
+		err := ValidateEventProcessor(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ECSCluster")
+	})
+
+	t.Run("missing ExecutionsTable", func(t *testing.T) {
+		cfg := &Config{
+			ECSCluster:                "cluster",
+			WebSocketAPIEndpoint:      "wss://example.com",
+			WebSocketConnectionsTable: "connections",
+			WebSocketTokensTable:      "tokens",
+		}
+		err := ValidateEventProcessor(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ExecutionsTable")
+	})
+
+	t.Run("valid config and normalization", func(t *testing.T) {
+		cfg := &Config{
+			ECSCluster:                "cluster",
+			ExecutionsTable:           "executions",
+			WebSocketAPIEndpoint:      "wss://example.com",
+			WebSocketConnectionsTable: "connections",
+			WebSocketTokensTable:      "tokens",
+		}
+		err := ValidateEventProcessor(cfg)
+		assert.NoError(t, err)
+		// Check that endpoint was normalized and https:// added
+		assert.Equal(t, "https://example.com", cfg.WebSocketAPIEndpoint)
+	})
+
+	t.Run("endpoint already normalized", func(t *testing.T) {
+		cfg := &Config{
+			ECSCluster:                "cluster",
+			ExecutionsTable:           "executions",
+			WebSocketAPIEndpoint:      "example.com",
+			WebSocketConnectionsTable: "connections",
+			WebSocketTokensTable:      "tokens",
+		}
+		err := ValidateEventProcessor(cfg)
+		assert.NoError(t, err)
+		assert.Equal(t, "https://example.com", cfg.WebSocketAPIEndpoint)
+	})
+}

--- a/internal/database/secrets_test.go
+++ b/internal/database/secrets_test.go
@@ -1,0 +1,22 @@
+// Package database defines the repository interfaces for data persistence.
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSecretsErrors(t *testing.T) {
+	t.Run("ErrSecretNotFound", func(t *testing.T) {
+		err := ErrSecretNotFound
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "secret not found")
+	})
+
+	t.Run("ErrSecretAlreadyExists", func(t *testing.T) {
+		err := ErrSecretAlreadyExists
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "secret already exists")
+	})
+}

--- a/internal/providers/aws/constants/logstream_test.go
+++ b/internal/providers/aws/constants/logstream_test.go
@@ -1,0 +1,115 @@
+// Package constants provides AWS-specific constants and utilities for log stream handling.
+package constants
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildLogStreamName(t *testing.T) {
+	tests := []struct {
+		name        string
+		executionID string
+		expected    string
+	}{
+		{
+			name:        "normal execution ID",
+			executionID: "abc123",
+			expected:    "task/runner/abc123",
+		},
+		{
+			name:        "UUID-like execution ID",
+			executionID: "550e8400-e29b-41d4-a716-446655440000",
+			expected:    "task/runner/550e8400-e29b-41d4-a716-446655440000",
+		},
+		{
+			name:        "empty execution ID",
+			executionID: "",
+			expected:    "task/runner/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := BuildLogStreamName(tt.executionID)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractExecutionIDFromLogStream(t *testing.T) {
+	tests := []struct {
+		name      string
+		logStream string
+		expected  string
+	}{
+		{
+			name:      "valid runner log stream",
+			logStream: "task/runner/abc123",
+			expected:  "abc123",
+		},
+		{
+			name:      "valid sidecar log stream",
+			logStream: "task/sidecar/abc123",
+			expected:  "abc123",
+		},
+		{
+			name:      "UUID-like execution ID",
+			logStream: "task/runner/550e8400-e29b-41d4-a716-446655440000",
+			expected:  "550e8400-e29b-41d4-a716-446655440000",
+		},
+		{
+			name:      "empty log stream",
+			logStream: "",
+			expected:  "",
+		},
+		{
+			name:      "invalid format - too few parts",
+			logStream: "task/runner",
+			expected:  "",
+		},
+		{
+			name:      "invalid format - too many parts",
+			logStream: "task/runner/abc123/extra",
+			expected:  "",
+		},
+		{
+			name:      "invalid format - wrong prefix",
+			logStream: "log/runner/abc123",
+			expected:  "",
+		},
+		{
+			name:      "invalid format - unknown container",
+			logStream: "task/unknown/abc123",
+			expected:  "",
+		},
+		{
+			name:      "invalid format - empty execution ID",
+			logStream: "task/runner/",
+			expected:  "",
+		},
+		{
+			name:      "invalid format - no slashes",
+			logStream: "taskrunnerabc123",
+			expected:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractExecutionIDFromLogStream(tt.logStream)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestBuildAndExtractLogStreamRoundTrip(t *testing.T) {
+	t.Run("build and extract round trip", func(t *testing.T) {
+		executionID := "test-exec-123"
+		logStream := BuildLogStreamName(executionID)
+		extracted := ExtractExecutionIDFromLogStream(logStream)
+
+		assert.Equal(t, executionID, extracted)
+	})
+}

--- a/internal/providers/aws/secrets/manager_test.go
+++ b/internal/providers/aws/secrets/manager_test.go
@@ -1,0 +1,109 @@
+// Package secrets provides secret management functionality for the Runvoy orchestrator.
+package secrets
+
+import (
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetParameterName(t *testing.T) {
+	logger := slog.Default()
+	m := NewParameterStoreManager(nil, "/runvoy/secrets", "arn:aws:kms:us-east-1:123456789012:key/abc", logger)
+
+	t.Run("constructs correct parameter name", func(t *testing.T) {
+		name := m.getParameterName("db-password")
+		assert.Equal(t, "/runvoy/secrets/db-password", name)
+	})
+
+	t.Run("handles empty prefix", func(t *testing.T) {
+		m2 := NewParameterStoreManager(nil, "", "arn:aws:kms:us-east-1:123456789012:key/abc", logger)
+		name := m2.getParameterName("db-password")
+		assert.Equal(t, "/db-password", name)
+	})
+
+	t.Run("handles prefix without leading slash", func(t *testing.T) {
+		m2 := NewParameterStoreManager(nil, "runvoy/secrets", "arn:aws:kms:us-east-1:123456789012:key/abc", logger)
+		name := m2.getParameterName("db-password")
+		assert.Equal(t, "runvoy/secrets/db-password", name)
+	})
+}
+
+func TestIsParameterNotFound(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "ParameterNotFound error",
+			err:      errors.New("ParameterNotFound"),
+			expected: true,
+		},
+		{
+			name:     "InvalidParameters error",
+			err:      errors.New("InvalidParameters: [/runvoy/secrets/test]"),
+			expected: true,
+		},
+		{
+			name:     "other error",
+			err:      errors.New("some other error"),
+			expected: false,
+		},
+		{
+			name:     "access denied error",
+			err:      errors.New("AccessDeniedException"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isParameterNotFound(tt.err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNewParameterStoreManager(t *testing.T) {
+	t.Run("creates manager with correct fields", func(t *testing.T) {
+		logger := slog.Default()
+		prefix := "/runvoy/secrets"
+		kmsKey := "arn:aws:kms:us-east-1:123456789012:key/abc"
+
+		m := NewParameterStoreManager(nil, prefix, kmsKey, logger)
+
+		require.NotNil(t, m)
+		assert.Equal(t, prefix, m.secretPrefix)
+		assert.Equal(t, kmsKey, m.kmsKeyARN)
+		assert.NotNil(t, m.logger)
+		assert.Nil(t, m.client)
+	})
+}
+
+func TestParameterTags(t *testing.T) {
+	logger := slog.Default()
+	m := NewParameterStoreManager(nil, "/runvoy/secrets", "arn:aws:kms:us-east-1:123456789012:key/abc", logger)
+
+	t.Run("returns correct tags", func(t *testing.T) {
+		tags := m.parameterTags()
+
+		require.Len(t, tags, 2)
+
+		// Check Application tag
+		assert.Equal(t, "Application", *tags[0].Key)
+		assert.Equal(t, "runvoy", *tags[0].Value)
+
+		// Check ManagedBy tag
+		assert.Equal(t, "ManagedBy", *tags[1].Key)
+		assert.Equal(t, "runvoy-orchestrator", *tags[1].Value)
+	})
+}


### PR DESCRIPTION
This commit adds comprehensive unit tests for several packages to improve overall code coverage:

Added test coverage for:
- internal/api: Tests for all API types including executions, users, secrets, images, logs, and websocket messages with JSON marshaling/unmarshaling
- internal/config/aws: Tests for AWS configuration validation and endpoint normalization (0% → 53.8%)
- internal/database: Tests for error types and constants
- internal/providers/aws/constants: Tests for log stream name building and extraction (0% → 100%)
- internal/providers/aws/secrets: Tests for parameter store manager initialization and helper functions (0% → 16.3%)
- internal/app/events: Tests for WebSocket response type

Coverage improvements by package:
- internal/config/aws: 0% → 53.8%
- internal/providers/aws/constants: 0% → 100%
- internal/providers/aws/secrets: 0% → 16.3%
- Overall: 34.7% → 35.8%

The tests focus on:
- Type marshaling/unmarshaling validation
- Configuration validation logic
- Error handling and edge cases
- Helper function correctness