### PR TITLE
Fix buildRoleComposite function in DynamoDB images

### DIFF
--- a/internal/providers/aws/database/dynamodb/images.go
+++ b/internal/providers/aws/database/dynamodb/images.go
@@ -69,20 +69,6 @@ func (item *imageTaskDefItem) isDefault() bool {
 	return item.IsDefaultPlaceholder != nil && *item.IsDefaultPlaceholder == defaultPlaceholderValue
 }
 
-// buildRoleComposite creates a composite sort key from role names.
-// Returns "default#default" if both are nil, otherwise "roleName1#roleName2".
-func buildRoleComposite(taskRoleName, taskExecutionRoleName *string) string {
-	taskRole := defaultRoleName
-	execRole := defaultRoleName
-	if taskRoleName != nil && *taskRoleName != "" {
-		taskRole = *taskRoleName
-	}
-	if taskExecutionRoleName != nil && *taskExecutionRoleName != "" {
-		execRole = *taskExecutionRoleName
-	}
-	return fmt.Sprintf("%s#%s", taskRole, execRole)
-}
-
 // GenerateImageID generates a unique, human-readable ID for an image configuration.
 // Format: {imageName}:{tag}-{first-8-chars-of-hash}
 // Example: alpine:latest-a1b2c3d4 or golang:1.24.5-bookworm-19884ca2
@@ -92,7 +78,17 @@ func GenerateImageID(
 	runtimePlatform string,
 	taskRoleName, taskExecutionRoleName *string,
 ) string {
-	roleComposite := buildRoleComposite(taskRoleName, taskExecutionRoleName)
+	// Build role composite inline
+	taskRole := defaultRoleName
+	execRole := defaultRoleName
+	if taskRoleName != nil && *taskRoleName != "" {
+		taskRole = *taskRoleName
+	}
+	if taskExecutionRoleName != nil && *taskExecutionRoleName != "" {
+		execRole = *taskExecutionRoleName
+	}
+	roleComposite := fmt.Sprintf("%s#%s", taskRole, execRole)
+
 	hashInput := fmt.Sprintf("%s:%s:%d:%d:%s:%s", imageName, imageTag, cpu, memory, runtimePlatform, roleComposite)
 	hash := sha256.Sum256([]byte(hashInput))
 	hashStr := fmt.Sprintf("%x", hash)


### PR DESCRIPTION
The buildRoleComposite function was a helper that created a composite key from role names. Since it's only used in one place (GenerateImageID), the logic has been inlined directly into that function to simplify the codebase. The roles are still part of the ImageID hash calculation as intended.

Changes:
- Removed buildRoleComposite function definition
- Inlined role composite logic into GenerateImageID
- Removed TestBuildRoleComposite test function
- Updated test assertions to check role fields directly