### PR TITLE
Fix UpdateSecret to preserve metadata when not provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ runvoy --help
 ```
 
 ```text
-runvoy - 0.1.0-20251115-374ab29
+runvoy - 0.1.0-20251115-c1abf0a
 Isolated, repeatable execution environments for your commands
 
 Usage:


### PR DESCRIPTION
Previously, UpdateSecret would overwrite KeyName and Description with empty values if they weren't provided in the update request. This fix:

- Retrieves existing secret metadata before updating
- Preserves existing KeyName if not provided in the update
- Preserves existing Description if not provided in the update
- Only updates fields that were explicitly provided

This allows partial updates to secrets (e.g., updating only the value or only the description) without losing other metadata.