### PR TITLE
Parallelize AWS health manager reconcile tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ runvoy --help
 ```
 
 ```text
-runvoy - 0.1.0-20251116-1a640ba
+runvoy - 0.1.0-20251116-852d6cf
 Isolated, repeatable execution environments for your commands
 
 Usage:


### PR DESCRIPTION
Refactored the Reconcile() function to run ECS task definitions, secrets, and IAM roles reconciliation in parallel using golang.org/x/sync/errgroup. This improves performance by executing independent reconciliation tasks concurrently instead of sequentially.

Changes:
- Added errgroup and sync imports
- Created goroutines for each reconciliation task
- Used mutex to safely collect results from parallel tasks
- Maintained error handling and context propagation