### PR TITLE
Embed Casbin configuration files into binary

### DIFF
--- a/internal/providers/aws/orchestrator/init.go
+++ b/internal/providers/aws/orchestrator/init.go
@@ -101,12 +101,8 @@ func Initialize( //nolint:funlen // This is ok, lots of initializations required
 		log,
 	)
 
-	// Initialize Casbin enforcer for authorization
-	enforcer, err := authorization.NewEnforcer(
-		"internal/auth/casbin/model.conf",
-		"internal/auth/casbin/policy.csv",
-		log,
-	)
+	// Initialize Casbin enforcer for authorization with embedded configuration
+	enforcer, err := authorization.NewEnforcer(log)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize authorization enforcer: %w", err)
 	}


### PR DESCRIPTION
Changed the authorization enforcer to use Go's embed package for loading Casbin model and policy configurations. This makes the enforcer portable and suitable for Lambda deployments where file paths are unreliable.

Changes:
- Add //go:embed directives for model.conf and policy.csv
- Update NewEnforcer to accept only logger (no file paths)
- Use model.NewModelFromString() to load model from embedded string
- Implement loadPoliciesFromCSV() to parse and load policies programmatically
- Update AWS orchestrator initialization to call NewEnforcer without paths

Benefits:
- No file system dependencies
- Works in Lambda, containers, and local environments
- Configuration embedded at compile time
- More secure and portable