### PR TITLE
Review AWS orchestrator client implementation

### DIFF
--- a/internal/providers/aws/client/cloudwatchlogs.go
+++ b/internal/providers/aws/client/cloudwatchlogs.go
@@ -1,4 +1,4 @@
-package orchestrator
+package client
 
 import (
 	"context"

--- a/internal/providers/aws/orchestrator/init.go
+++ b/internal/providers/aws/orchestrator/init.go
@@ -62,7 +62,7 @@ func Initialize( //nolint:funlen // This is ok, lots of initializations required
 	dynamoClient := dynamoRepo.NewClientAdapter(dynamoSDKClient)
 	ecsClient := awsClient.NewECSClientAdapter(ecsSDKClient)
 	ssmClient := secrets.NewClientAdapter(ssmSDKClient)
-	cwlClient := NewCloudWatchLogsClientAdapter(cwlSDKClient)
+	cwlClient := awsClient.NewCloudWatchLogsClientAdapter(cwlSDKClient)
 	iamClient := awsClient.NewIAMClientAdapter(iamSDKClient)
 
 	repos := createRepositories(dynamoClient, ssmClient, cfg, log)

--- a/internal/providers/aws/orchestrator/logs.go
+++ b/internal/providers/aws/orchestrator/logs.go
@@ -10,6 +10,7 @@ import (
 	"runvoy/internal/api"
 	appErrors "runvoy/internal/errors"
 	"runvoy/internal/logger"
+	awsClient "runvoy/internal/providers/aws/client"
 	awsConstants "runvoy/internal/providers/aws/constants"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -20,7 +21,7 @@ import (
 // verifyLogStreamExists checks if the log stream exists and returns an error if it doesn't
 func verifyLogStreamExists(
 	ctx context.Context,
-	cwl CloudWatchLogsClient,
+	cwl awsClient.CloudWatchLogsClient,
 	logGroup, stream, executionID string,
 	reqLogger *slog.Logger,
 ) error {
@@ -55,7 +56,7 @@ func verifyLogStreamExists(
 // for the provided log group and stream. It returns the aggregated sorted by timestamp
 // events or an error.
 func getAllLogEvents(ctx context.Context,
-	cwl CloudWatchLogsClient, logGroup string, stream string) ([]api.LogEvent, error) {
+	cwl awsClient.CloudWatchLogsClient, logGroup string, stream string) ([]api.LogEvent, error) {
 	var events []api.LogEvent
 	var nextToken *string
 	pageCount := 0

--- a/internal/providers/aws/orchestrator/runner.go
+++ b/internal/providers/aws/orchestrator/runner.go
@@ -73,7 +73,7 @@ type ImageTaskDefRepository interface {
 // Runner implements app.Runner for AWS ECS Fargate.
 type Runner struct {
 	ecsClient awsClient.ECSClient
-	cwlClient CloudWatchLogsClient
+	cwlClient awsClient.CloudWatchLogsClient
 	iamClient awsClient.IAMClient
 	imageRepo ImageTaskDefRepository
 	cfg       *Config
@@ -83,7 +83,7 @@ type Runner struct {
 // NewRunner creates a new AWS ECS runner with the provided configuration.
 func NewRunner(
 	ecsClient awsClient.ECSClient,
-	cwlClient CloudWatchLogsClient,
+	cwlClient awsClient.CloudWatchLogsClient,
 	iamClient awsClient.IAMClient,
 	imageRepo ImageTaskDefRepository,
 	cfg *Config,


### PR DESCRIPTION
Moved internal/providers/aws/orchestrator/client.go to internal/providers/aws/client/cloudwatchlogs.go for better organization and consistency.

Rationale:
- The CloudWatch Logs client follows the same pattern as ECS and IAM clients (interface + adapter wrapper)
- The aws/client package is documented as the place for "AWS-specific client interfaces for AWS services"
- Separates infrastructure concerns from orchestrator business logic
- Improves discoverability and reusability

Changes:
- Created internal/providers/aws/client/cloudwatchlogs.go with CloudWatchLogsClient interface and adapter
- Updated imports in orchestrator package files to use awsClient.CloudWatchLogsClient
- Removed internal/providers/aws/orchestrator/client.go