### PR TITLE
Fix event processor SSM permissions

### DIFF
--- a/deploy/providers/aws/cloudformation-backend.yaml
+++ b/deploy/providers/aws/cloudformation-backend.yaml
@@ -749,8 +749,11 @@ Resources:
                 Resource: '*'
               - Effect: Allow
                 Action:
-                  - 'ssm:GetParameter'
                   - 'ssm:DescribeParameters'
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - 'ssm:GetParameter'
                   - 'ssm:ListTagsForResource'
                   - 'ssm:AddTagsToResource'
                 Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/runvoy/secrets/*'


### PR DESCRIPTION
Fix Event Processor Lambda's SSM policy to allow `ssm:DescribeParameters` on `*`.

The `ssm:DescribeParameters` action is a list operation that must be allowed on `*` (all resources) rather than a specific parameter path. The previous policy incorrectly scoped this action, leading to `AccessDeniedException` during health reconciliation.

---
<a href="https://cursor.com/background-agent?bcId=bc-17080361-8c38-4c88-8c2a-d3dc10579ea7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-17080361-8c38-4c88-8c2a-d3dc10579ea7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

