### PR TITLE
Fix flaky unit tests

### DIFF
--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -3,8 +3,8 @@ package testutil
 
 import (
 	"context"
+	"io"
 	"log/slog"
-	"os"
 	"time"
 
 	"runvoy/internal/api"
@@ -147,7 +147,7 @@ func TestLogger() *slog.Logger {
 
 // SilentLogger creates a logger that discards all output.
 func SilentLogger() *slog.Logger {
-	return slog.New(slog.NewTextHandler(os.NewFile(0, os.DevNull), &slog.HandlerOptions{
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{
 		Level: slog.LevelError + 1, // Suppress all logs
 	}))
 }


### PR DESCRIPTION
…gger

The SilentLogger function was using os.NewFile(0, os.DevNull) which incorrectly wraps file descriptor 0 (stdin) instead of opening /dev/null. This caused race conditions during coverage report generation, resulting in "bad file descriptor" errors.

Replace with io.Discard which is the idiomatic Go way to discard output.