### PR TITLE
Standardize layout consistency across webapp views

### DIFF
--- a/cmd/webapp/src/views/LogsView.svelte
+++ b/cmd/webapp/src/views/LogsView.svelte
@@ -244,17 +244,24 @@
         </p>
     </article>
 {:else}
-    <section>
+    <article class="logs-card">
         <StatusBar onKill={handleKillExecution} />
         <WebSocketStatus />
         <LogControls />
         <LogViewer />
-    </section>
+    </article>
 {/if}
 
 <style>
     article {
         margin-top: 2rem;
+    }
+
+    .logs-card {
+        background: var(--pico-card-background-color);
+        border: 1px solid var(--pico-card-border-color);
+        border-radius: var(--pico-border-radius);
+        padding: 2rem;
     }
 
     .status-check-error-modal {
@@ -300,6 +307,10 @@
     @media (max-width: 768px) {
         article {
             margin-top: 1.5rem;
+        }
+
+        .logs-card {
+            padding: 1.5rem;
         }
 
         .status-check-error-modal {

--- a/cmd/webapp/src/views/RunView.svelte
+++ b/cmd/webapp/src/views/RunView.svelte
@@ -129,7 +129,8 @@
         </p>
     </article>
 {:else}
-    <form on:submit|preventDefault={handleSubmit} class="run-form">
+    <article class="run-card">
+        <form on:submit|preventDefault={handleSubmit} class="run-form">
         <fieldset>
             <legend>Command</legend>
             <label for="command-input">
@@ -249,6 +250,7 @@
             </button>
         </div>
     </form>
+    </article>
 {/if}
 
 <style>
@@ -257,6 +259,13 @@
         border: 1px solid var(--pico-card-border-color);
         border-radius: var(--pico-border-radius);
         padding: 1.5rem;
+    }
+
+    .run-card {
+        background: var(--pico-card-background-color);
+        border: 1px solid var(--pico-card-border-color);
+        border-radius: var(--pico-border-radius);
+        padding: 2rem;
     }
 
     .run-form {
@@ -313,8 +322,9 @@
     }
 
     @media (max-width: 768px) {
-        .info-card {
-            padding: 1rem;
+        .info-card,
+        .run-card {
+            padding: 1.5rem;
         }
 
         .run-form {


### PR DESCRIPTION
Unify all webapp views to use the same card-based layout structure:
- Wrap RunView form in card container with consistent styling
- Wrap LogsView main content in card container
- Both now match ClaimView and SettingsView layouts
- Add .run-card and .logs-card classes with matching styling:
  * Background, border, border-radius, and padding (2rem)
  * Responsive padding for mobile (1.5rem)

This ensures all views have the same visual appearance with a consistent box/card wrapper around their content.