### PR TITLE
Add health check display to settings view

### DIFF
--- a/cmd/webapp/src/lib/api.ts
+++ b/cmd/webapp/src/lib/api.ts
@@ -9,6 +9,7 @@ import type {
     KillExecutionResponse,
     ListExecutionsResponse,
     ClaimAPIKeyResponse,
+    HealthResponse,
     ApiError
 } from '../types/api';
 
@@ -158,6 +159,24 @@ export class APIClient {
      */
     async claimAPIKey(token: string): Promise<ClaimAPIKeyResponse> {
         const url = this.joinUrl(this.endpoint, 'api/v1/claim', token);
+        const response = await fetch(url);
+
+        if (!response.ok) {
+            const errorData = await response.json().catch(() => ({}));
+            const error = new Error(errorData.details || `HTTP ${response.status}`) as ApiError;
+            error.status = response.status;
+            error.details = errorData;
+            throw error;
+        }
+
+        return response.json();
+    }
+
+    /**
+     * Get backend health status and version
+     */
+    async getHealth(): Promise<HealthResponse> {
+        const url = this.joinUrl(this.endpoint, 'api/v1/health');
         const response = await fetch(url);
 
         if (!response.ok) {

--- a/cmd/webapp/src/types/api.ts
+++ b/cmd/webapp/src/types/api.ts
@@ -68,6 +68,11 @@ export interface ClaimAPIKeyResponse {
     message?: string;
 }
 
+export interface HealthResponse {
+    status: string;
+    version: string;
+}
+
 export interface APIClientConfig {
     endpoint: string;
     apiKey: string;


### PR DESCRIPTION
- Add HealthResponse type to API types
- Implement getHealth method in APIClient
- Display backend version and status in settings view
- Show loading, error, and success states for health check
- Automatically fetch health info when settings page loads
- Re-fetch health when API configuration changes