### PR TITLE
Update modified_by_request_id on execution completion

### DIFF
--- a/internal/backend/orchestrator/executions.go
+++ b/internal/backend/orchestrator/executions.go
@@ -132,7 +132,7 @@ func (s *Service) recordExecution(
 		startedAt = createdAt.UTC()
 	}
 
-	requestID := logger.GetRequestID(ctx)
+	requestID := logger.ExtractRequestIDFromContext(ctx)
 	execution := &api.Execution{
 		ExecutionID:         executionID,
 		CreatedBy:           userEmail,
@@ -305,7 +305,7 @@ func (s *Service) KillExecution(ctx context.Context, executionID string) (*api.K
 	execution.CompletedAt = nil
 
 	// Extract request ID from context and set ModifiedByRequestID
-	requestID := logger.GetRequestID(ctx)
+	requestID := logger.ExtractRequestIDFromContext(ctx)
 	if requestID != "" {
 		execution.ModifiedByRequestID = requestID
 	}

--- a/internal/providers/aws/processor/ecs_events.go
+++ b/internal/providers/aws/processor/ecs_events.go
@@ -107,7 +107,7 @@ func (p *Processor) updateExecutionToRunning(
 	execution.CompletedAt = nil
 
 	// Extract request ID from context and set ModifiedByRequestID
-	requestID := logger.GetRequestID(ctx)
+	requestID := logger.ExtractRequestIDFromContext(ctx)
 	if requestID != "" {
 		execution.ModifiedByRequestID = requestID
 	}
@@ -162,7 +162,7 @@ func (p *Processor) finalizeExecutionFromTaskEvent(
 	execution.DurationSeconds = durationSeconds
 
 	// Extract request ID from context and set ModifiedByRequestID
-	requestID := logger.GetRequestID(ctx)
+	requestID := logger.ExtractRequestIDFromContext(ctx)
 	if requestID != "" {
 		execution.ModifiedByRequestID = requestID
 	}


### PR DESCRIPTION
…ecutions

Previously, the code was using logger.GetRequestID(ctx) which only checks for request IDs set via WithRequestID in the context value. This caused the modified_by_request_id field to not be set when the Lambda event processor updated executions with their final status.

The fix replaces logger.GetRequestID(ctx) with logger.ExtractRequestIDFromContext(ctx) which first tries GetRequestID and then falls back to registered ContextExtractors, including the LambdaContextExtractor that extracts AWS Lambda request IDs from the Lambda context.

This ensures that:
1. When an execution is created, modified_by_request_id is set
2. When the Lambda event processor updates it to RUNNING, modified_by_request_id is set
3. When the Lambda event processor seals it with final status, modified_by_request_id is set

Changes made in:
- internal/providers/aws/processor/ecs_events.go (updateExecutionToRunning and finalizeExecutionFromTaskEvent)
- internal/backend/orchestrator/executions.go (recordExecution and KillExecution)