### PR TITLE
Fix empty logs in trace output endpoint

### DIFF
--- a/internal/providers/aws/orchestrator/logs.go
+++ b/internal/providers/aws/orchestrator/logs.go
@@ -161,8 +161,8 @@ func (r *Provider) startBackendLogsQuery(
 	}
 
 	queryString := fmt.Sprintf(`fields @timestamp, @message
-		| filter %s = "%s"
-		| sort @timestamp asc`, constants.RequestIDLogField, requestID)
+| filter %s = "%s"
+| sort @timestamp asc`, constants.RequestIDLogField, requestID)
 
 	startQueryArgs := []any{
 		"operation", "CloudWatchLogs.StartQuery",


### PR DESCRIPTION
Remove unnecessary indentation/tabs from the CloudWatch query string to ensure consistent formatting.