### PR TITLE
Improve unit test coverage and plan next steps

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -849,6 +849,65 @@ func TestNormalizeBackendProvider(t *testing.T) {
 	}
 }
 
+func TestNormalizeStringSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "empty slice",
+			input:    []string{},
+			expected: []string{},
+		},
+		{
+			name:     "single element without comma",
+			input:    []string{"value1"},
+			expected: []string{"value1"},
+		},
+		{
+			name:     "single element with comma-separated values",
+			input:    []string{"value1,value2,value3"},
+			expected: []string{"value1", "value2", "value3"},
+		},
+		{
+			name:     "single element with comma and spaces",
+			input:    []string{"value1, value2 , value3"},
+			expected: []string{"value1", "value2", "value3"},
+		},
+		{
+			name:     "single element with empty values in comma list",
+			input:    []string{"value1,,value2, ,value3"},
+			expected: []string{"value1", "value2", "value3"},
+		},
+		{
+			name:     "multiple elements (not normalized)",
+			input:    []string{"value1", "value2", "value3"},
+			expected: []string{"value1", "value2", "value3"},
+		},
+		{
+			name:     "single element with only commas",
+			input:    []string{",,,"},
+			expected: []string{",,,"}, // Function only splits if comma-separated values exist
+		},
+		{
+			name:     "single element with whitespace only",
+			input:    []string{"   "},
+			expected: []string{"   "},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a copy to avoid modifying the original
+			input := make([]string, len(tt.input))
+			copy(input, tt.input)
+			normalizeStringSlice(&input)
+			assert.Equal(t, tt.expected, input)
+		})
+	}
+}
+
 // TestLoadWithEnvironmentVariables tests Load() with environment variables
 func TestLoadWithEnvironmentVariables(t *testing.T) {
 	// Save original env vars

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -372,6 +372,51 @@ func (m *mockContextExtractor) ExtractRequestID(_ context.Context) (string, bool
 	return m.requestID, m.shouldFind
 }
 
+func TestRegisterContextExtractor(t *testing.T) {
+	t.Run("registers extractor and appends to list", func(t *testing.T) {
+		// Save and restore original extractors
+		originalExtractors := contextExtractors
+		defer func() { contextExtractors = originalExtractors }()
+
+		ClearContextExtractors()
+
+		extractor1 := &mockContextExtractor{requestID: "ext1", shouldFind: true}
+		extractor2 := &mockContextExtractor{requestID: "ext2", shouldFind: true}
+
+		RegisterContextExtractor(extractor1)
+		RegisterContextExtractor(extractor2)
+
+		// Verify both extractors are registered
+		require.Len(t, contextExtractors, 2)
+		assert.Equal(t, extractor1, contextExtractors[0])
+		assert.Equal(t, extractor2, contextExtractors[1])
+	})
+}
+
+func TestClearContextExtractors(t *testing.T) {
+	t.Run("clears all registered extractors", func(t *testing.T) {
+		// Save and restore original extractors
+		originalExtractors := contextExtractors
+		defer func() { contextExtractors = originalExtractors }()
+
+		// Register some extractors
+		extractor1 := &mockContextExtractor{requestID: "ext1", shouldFind: true}
+		extractor2 := &mockContextExtractor{requestID: "ext2", shouldFind: true}
+		RegisterContextExtractor(extractor1)
+		RegisterContextExtractor(extractor2)
+
+		// Verify extractors are registered
+		require.Len(t, contextExtractors, 2)
+
+		// Clear extractors
+		ClearContextExtractors()
+
+		// Verify extractors are cleared
+		assert.Nil(t, contextExtractors)
+		assert.Len(t, contextExtractors, 0)
+	})
+}
+
 func TestContextExtractor(t *testing.T) {
 	t.Run("custom extractor can be registered and used", func(t *testing.T) {
 		// Save and restore original extractors


### PR DESCRIPTION
Add unit tests for `internal/errors`, `internal/logger`, and `internal/config` to improve coverage.

---
<a href="https://cursor.com/background-agent?bcId=bc-32353c4a-dc77-45d6-bb6c-d37a206f7818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-32353c4a-dc77-45d6-bb6c-d37a206f7818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

