### PR TITLE
Fix claim flow API configuration issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ runvoy --help
 ```
 
 ```text
-runvoy - v0.2.0-20251123-5cb83e8
+runvoy - v0.2.0-20251123-51c254d
 Isolated, repeatable execution environments for your commands
 
 Usage:

--- a/cmd/webapp/src/components/ConnectionManager.svelte
+++ b/cmd/webapp/src/components/ConnectionManager.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
     import { apiEndpoint, apiKey } from '../stores/config';
 
+    const MASKED_API_KEY_PLACEHOLDER = '••••••••';
+
     let showModal = false;
     let endpointInput = $apiEndpoint || '';
     let keyInput = '';
     let errorMessage = '';
 
     // Show masked key if already set
-    $: displayKey = $apiKey ? '••••••••' : '';
+    $: displayKey = $apiKey ? MASKED_API_KEY_PLACEHOLDER : '';
 
     function openModal(): void {
         showModal = true;
@@ -42,7 +44,7 @@
         apiEndpoint.set(endpoint);
 
         // Save API key only if provided and not the masked placeholder
-        if (key && key !== '••••••••') {
+        if (key && key !== MASKED_API_KEY_PLACEHOLDER) {
             apiKey.set(key);
         }
 
@@ -96,7 +98,10 @@
                         bind:value={keyInput}
                         placeholder={displayKey || 'Enter API key (or claim one later)'}
                     />
-                    <small>Your runvoy API key for authentication. Leave empty to claim one using an invitation token.</small>
+                    <small
+                        >Your runvoy API key for authentication. Leave empty to claim one using an
+                        invitation token.</small
+                    >
                 </label>
 
                 <div class="button-group">

--- a/cmd/webapp/src/components/ConnectionManager.test.ts
+++ b/cmd/webapp/src/components/ConnectionManager.test.ts
@@ -315,7 +315,9 @@ describe('ConnectionManager', () => {
             await fireEvent.click(screen.getByText('⚙️ Configure API'));
 
             const endpointInput = screen.getByLabelText(/API Endpoint:/);
-            await fireEvent.input(endpointInput, { target: { value: 'https://api.example.com/runvoy/v1' } });
+            await fireEvent.input(endpointInput, {
+                target: { value: 'https://api.example.com/runvoy/v1' }
+            });
 
             const saveButton = screen.getByText('Save');
             await fireEvent.click(saveButton);
@@ -330,7 +332,9 @@ describe('ConnectionManager', () => {
             await fireEvent.click(screen.getByText('⚙️ Configure API'));
 
             const endpointInput = screen.getByLabelText(/API Endpoint:/);
-            await fireEvent.input(endpointInput, { target: { value: '  https://api.example.com  ' } });
+            await fireEvent.input(endpointInput, {
+                target: { value: '  https://api.example.com  ' }
+            });
 
             const saveButton = screen.getByText('Save');
             await fireEvent.click(saveButton);
@@ -351,7 +355,9 @@ describe('ConnectionManager', () => {
             // Change only the endpoint, leave the masked API key
             const endpointInput = screen.getByLabelText(/API Endpoint:/);
             await fireEvent.input(endpointInput, { target: { value: '' } });
-            await fireEvent.input(endpointInput, { target: { value: 'https://new-api.example.com' } });
+            await fireEvent.input(endpointInput, {
+                target: { value: 'https://new-api.example.com' }
+            });
 
             const saveButton = screen.getByText('Save');
             await fireEvent.click(saveButton);
@@ -461,7 +467,9 @@ describe('ConnectionManager', () => {
 
             const endpointInput = screen.getByLabelText(/API Endpoint:/);
             await fireEvent.input(endpointInput, { target: { value: '' } });
-            await fireEvent.input(endpointInput, { target: { value: 'https://new-api.example.com' } });
+            await fireEvent.input(endpointInput, {
+                target: { value: 'https://new-api.example.com' }
+            });
 
             const apiKeyInput = screen.getByLabelText(/API Key \(optional\):/);
             await fireEvent.input(apiKeyInput, { target: { value: 'new-key-456' } });


### PR DESCRIPTION
The claim flow is designed to obtain an API key using an invitation token, but the ConnectionManager was requiring both endpoint and API key to be configured. This made it impossible to configure just the endpoint for the claim flow.

Changes:
- Remove validation requiring API key in saveCredentials()
- Only save API key if provided and not the masked placeholder
- Update UI to indicate API key is optional
- Add helpful placeholder text guiding users to claim flow
- Remove 'required' attribute from API key input field

This allows users to:
1. Configure only the API endpoint
2. Navigate to the claim page
3. Use their invitation token to obtain an API key
4. The API key is automatically saved to configuration