### PR TITLE
Add and test utility functions for coverage

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1338,34 +1338,34 @@ func TestLoadEventProcessorMissingRequiredFields(t *testing.T) {
 
 func TestConfig_GetProviderIdentifier(t *testing.T) {
 	tests := []struct {
-		name           string
+		name            string
 		backendProvider constants.BackendProvider
-		expected       string
+		expected        string
 	}{
 		{
-			name:           "AWS provider",
+			name:            "AWS provider",
 			backendProvider: constants.AWS,
-			expected:       "aws",
+			expected:        "aws",
 		},
 		{
-			name:           "empty provider",
+			name:            "empty provider",
 			backendProvider: "",
-			expected:       "",
+			expected:        "",
 		},
 		{
-			name:           "uppercase provider",
+			name:            "uppercase provider",
 			backendProvider: constants.BackendProvider("GCP"),
-			expected:       "gcp",
+			expected:        "gcp",
 		},
 		{
-			name:           "mixed case provider",
+			name:            "mixed case provider",
 			backendProvider: constants.BackendProvider("Azure"),
-			expected:       "azure",
+			expected:        "azure",
 		},
 		{
-			name:           "lowercase provider",
+			name:            "lowercase provider",
 			backendProvider: constants.BackendProvider("aws"),
-			expected:       "aws",
+			expected:        "aws",
 		},
 	}
 
@@ -1382,10 +1382,10 @@ func TestConfig_GetProviderIdentifier(t *testing.T) {
 
 func TestConfig_GetDefaultStackName(t *testing.T) {
 	tests := []struct {
-		name           string
-		config         *Config
-		expected       string
-		description    string
+		name        string
+		config      *Config
+		expected    string
+		description string
 	}{
 		{
 			name: "returns configured stack name when set",


### PR DESCRIPTION
Add unit tests for `GetProviderIdentifier()`, `GetDefaultStackName()`, and `saveToPath()` to improve code coverage.

---
<a href="https://cursor.com/background-agent?bcId=bc-8d3172d2-6d1b-4324-8310-165f511881bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8d3172d2-6d1b-4324-8310-165f511881bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

