### PR TITLE
Consolidate Go package documentation into single file

### DIFF
--- a/internal/api/doc.go
+++ b/internal/api/doc.go
@@ -1,0 +1,2 @@
+// Package api defines the API types and structures used across runvoy.
+package api

--- a/internal/api/executions.go
+++ b/internal/api/executions.go
@@ -1,4 +1,3 @@
-// Package api defines the API types and structures used across runvoy.
 package api
 
 import (

--- a/internal/api/executions_test.go
+++ b/internal/api/executions_test.go
@@ -1,4 +1,3 @@
-// Package api defines the API types and structures used across runvoy.
 package api
 
 import (

--- a/internal/api/images.go
+++ b/internal/api/images.go
@@ -1,4 +1,3 @@
-// Package api defines the API types and structures used across runvoy.
 package api
 
 import (

--- a/internal/api/images_test.go
+++ b/internal/api/images_test.go
@@ -1,4 +1,3 @@
-// Package api defines the API types and structures used across runvoy.
 package api
 
 import (

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -1,4 +1,3 @@
-// Package api defines the API types and structures used across runvoy.
 package api
 
 // LogEvent represents a single log event.

--- a/internal/api/logs_test.go
+++ b/internal/api/logs_test.go
@@ -1,4 +1,3 @@
-// Package api defines the API types and structures used across runvoy.
 package api
 
 import (

--- a/internal/api/playbooks.go
+++ b/internal/api/playbooks.go
@@ -1,4 +1,3 @@
-// Package api defines the API types and structures used across runvoy.
 package api
 
 // Playbook represents a reusable command execution configuration

--- a/internal/api/secrets.go
+++ b/internal/api/secrets.go
@@ -1,5 +1,3 @@
-// Package api defines the API types and structures used across runvoy.
-// This file contains request and response structures for the secrets API.
 package api
 
 import (

--- a/internal/api/secrets_test.go
+++ b/internal/api/secrets_test.go
@@ -1,4 +1,3 @@
-// Package api defines the API types and structures used across runvoy.
 package api
 
 import (

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -1,5 +1,3 @@
-// Package api defines the API types and structures used across runvoy.
-// It contains request and response structures for the orchestrator API.
 package api
 
 // ErrorResponse represents an error response

--- a/internal/api/types_test.go
+++ b/internal/api/types_test.go
@@ -1,4 +1,3 @@
-// Package api defines the API types and structures used across runvoy.
 package api
 
 import (

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -1,4 +1,3 @@
-// Package api defines the API types and structures used across runvoy.
 package api
 
 import (

--- a/internal/api/users_test.go
+++ b/internal/api/users_test.go
@@ -1,4 +1,3 @@
-// Package api defines the API types and structures used across runvoy.
 package api
 
 import (

--- a/internal/api/websocket.go
+++ b/internal/api/websocket.go
@@ -1,4 +1,3 @@
-// Package api defines the API types and structures used across runvoy.
 package api
 
 // WebSocketConnection represents a WebSocket connection record

--- a/internal/api/websocket_test.go
+++ b/internal/api/websocket_test.go
@@ -1,4 +1,3 @@
-// Package api defines the API types and structures used across runvoy.
 package api
 
 import (

--- a/internal/backend/health/doc.go
+++ b/internal/backend/health/doc.go
@@ -1,0 +1,2 @@
+// Package health provides health management functionality for runvoy.
+package health

--- a/internal/backend/health/health.go
+++ b/internal/backend/health/health.go
@@ -1,5 +1,3 @@
-// Package health provides health management functionality for runvoy.
-// It defines the interface for reconciling resources between metadata storage and cloud provider services.
 package health
 
 import (

--- a/internal/backend/orchestrator/doc.go
+++ b/internal/backend/orchestrator/doc.go
@@ -1,0 +1,2 @@
+// Package orchestrator provides the core orchestrator service for runvoy.
+package orchestrator

--- a/internal/backend/orchestrator/health.go
+++ b/internal/backend/orchestrator/health.go
@@ -1,5 +1,3 @@
-// Package orchestrator provides the core orchestrator service for runvoy.
-// This file contains health reconciliation functionality.
 package orchestrator
 
 import (

--- a/internal/backend/orchestrator/init.go
+++ b/internal/backend/orchestrator/init.go
@@ -1,5 +1,3 @@
-// Package orchestrator provides the core orchestrator service for runvoy.
-// It initializes and manages command execution and API request handling.
 package orchestrator
 
 import (

--- a/internal/backend/processor/backend.go
+++ b/internal/backend/processor/backend.go
@@ -1,4 +1,3 @@
-// Package processor provides event processing interfaces and utilities.
 package processor
 
 import (

--- a/internal/backend/processor/backend_test.go
+++ b/internal/backend/processor/backend_test.go
@@ -1,2 +1,1 @@
-// Package events provides event processing interfaces and utilities.
 package processor

--- a/internal/backend/processor/doc.go
+++ b/internal/backend/processor/doc.go
@@ -1,0 +1,2 @@
+// Package processor provides event processing interfaces and utilities.
+package processor

--- a/internal/backend/processor/init.go
+++ b/internal/backend/processor/init.go
@@ -1,5 +1,3 @@
-// Package processor provides event processing functionality for cloud provider events.
-// It handles asynchronous events from AWS services like EventBridge, CloudWatch Logs, and WebSocket lifecycle events.
 package processor
 
 import (

--- a/internal/backend/websocket/doc.go
+++ b/internal/backend/websocket/doc.go
@@ -1,0 +1,2 @@
+// Package websocket provides WebSocket management for runvoy.
+package websocket

--- a/internal/backend/websocket/manager.go
+++ b/internal/backend/websocket/manager.go
@@ -1,5 +1,3 @@
-// Package websocket provides WebSocket management for runvoy.
-// It handles connection lifecycle events and manages WebSocket connections.
 package websocket
 
 import (

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,5 +1,3 @@
-// Package client provides HTTP client functionality for the runvoy API.
-// It handles authentication, request/response serialization, and error handling.
 package client
 
 import (

--- a/internal/client/doc.go
+++ b/internal/client/doc.go
@@ -1,0 +1,2 @@
+// Package client provides HTTP client functionality for the runvoy API.
+package client

--- a/internal/client/infra/deploy.go
+++ b/internal/client/infra/deploy.go
@@ -1,4 +1,3 @@
-// Package infra provides infrastructure deployment functionality.
 package infra
 
 import (

--- a/internal/client/infra/doc.go
+++ b/internal/client/infra/doc.go
@@ -1,0 +1,2 @@
+// Package infra provides infrastructure deployment functionality.
+package infra

--- a/internal/client/infra/users.go
+++ b/internal/client/infra/users.go
@@ -1,4 +1,3 @@
-// Package infra provides infrastructure deployment functionality.
 package infra
 
 import (

--- a/internal/client/interface.go
+++ b/internal/client/interface.go
@@ -1,4 +1,3 @@
-// Package client provides HTTP client functionality for the runvoy API.
 package client
 
 import (

--- a/internal/client/playbooks/doc.go
+++ b/internal/client/playbooks/doc.go
@@ -1,0 +1,2 @@
+// Package playbooks provides functionality for loading and managing playbooks.
+package playbooks

--- a/internal/client/playbooks/executor.go
+++ b/internal/client/playbooks/executor.go
@@ -1,4 +1,3 @@
-// Package playbooks provides functionality for loading and managing playbooks.
 package playbooks
 
 import (

--- a/internal/client/playbooks/loader.go
+++ b/internal/client/playbooks/loader.go
@@ -1,4 +1,3 @@
-// Package playbooks provides functionality for loading and managing playbooks.
 package playbooks
 
 import (

--- a/internal/constants/config.go
+++ b/internal/constants/config.go
@@ -1,4 +1,3 @@
-// Package constants defines global constants used throughout runvoy.
 package constants
 
 // DefaultWebURL is the default URL of the web application HTML file.

--- a/internal/constants/context.go
+++ b/internal/constants/context.go
@@ -1,4 +1,3 @@
-// Package constants defines global constants used throughout runvoy.
 package constants
 
 // ConfigCtxKeyType is the type for the config context key

--- a/internal/constants/conversion.go
+++ b/internal/constants/conversion.go
@@ -1,4 +1,3 @@
-// Package constants defines global constants used throughout runvoy.
 package constants
 
 // MillisecondsPerSecond is the number of milliseconds in a second

--- a/internal/constants/crypto.go
+++ b/internal/constants/crypto.go
@@ -1,4 +1,3 @@
-// Package constants defines global constants used throughout runvoy.
 package constants
 
 // APIKeyByteSize is the number of random bytes used to generate API keys

--- a/internal/constants/doc.go
+++ b/internal/constants/doc.go
@@ -1,0 +1,2 @@
+// Package constants defines global constants used throughout runvoy.
+package constants

--- a/internal/constants/execution.go
+++ b/internal/constants/execution.go
@@ -1,4 +1,3 @@
-// Package constants defines global constants used throughout runvoy.
 package constants
 
 import "slices"

--- a/internal/constants/git.go
+++ b/internal/constants/git.go
@@ -1,4 +1,3 @@
-// Package constants defines global constants used throughout runvoy.
 package constants
 
 // DefaultGitRef is the default Git reference to use if no reference is provided

--- a/internal/constants/http.go
+++ b/internal/constants/http.go
@@ -1,4 +1,3 @@
-// Package constants defines global constants used throughout runvoy.
 package constants
 
 import "time"

--- a/internal/constants/tags.go
+++ b/internal/constants/tags.go
@@ -1,4 +1,3 @@
-// Package constants defines global constants used throughout runvoy.
 package constants
 
 // ResourceApplicationTagKey is the tag key for Application.

--- a/internal/constants/time.go
+++ b/internal/constants/time.go
@@ -1,4 +1,3 @@
-// Package constants defines global constants used throughout runvoy.
 package constants
 
 import "time"

--- a/internal/constants/types.go
+++ b/internal/constants/types.go
@@ -1,4 +1,3 @@
-// Package constants defines global constants used throughout runvoy.
 package constants
 
 // BackendProvider represents the backend infrastructure provider.

--- a/internal/constants/ui.go
+++ b/internal/constants/ui.go
@@ -1,4 +1,3 @@
-// Package constants defines global constants used throughout runvoy.
 package constants
 
 // HeaderSeparatorLength is the length of the header separator line

--- a/internal/constants/validation.go
+++ b/internal/constants/validation.go
@@ -1,4 +1,3 @@
-// Package constants defines global constants used throughout runvoy.
 package constants
 
 // ExecutionsSliceInitialCapacity is the initial capacity for executions slices

--- a/internal/constants/version.go
+++ b/internal/constants/version.go
@@ -1,4 +1,3 @@
-// Package constants defines global constants used throughout runvoy.
 package constants
 
 var version = "0.0.0-development" // Updated by CI/CD pipeline at build time

--- a/internal/constants/websocket.go
+++ b/internal/constants/websocket.go
@@ -1,4 +1,3 @@
-// Package constants defines global constants used throughout runvoy.
 package constants
 
 // ConnectionTTLHours is the time-to-live for connection records in the database (24 hours)

--- a/internal/database/doc.go
+++ b/internal/database/doc.go
@@ -1,0 +1,2 @@
+// Package database defines repository interfaces for data persistence.
+package database

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -1,5 +1,3 @@
-// Package database defines repository interfaces for data persistence.
-// It provides abstractions for user and execution storage.
 package database
 
 import (

--- a/internal/database/secrets.go
+++ b/internal/database/secrets.go
@@ -1,5 +1,3 @@
-// Package database defines the repository interfaces for data persistence.
-// This file contains the SecretsRepository interface for secret metadata management.
 package database
 
 import (

--- a/internal/database/secrets_test.go
+++ b/internal/database/secrets_test.go
@@ -1,4 +1,3 @@
-// Package database defines the repository interfaces for data persistence.
 package database
 
 import (

--- a/internal/providers/aws/client/doc.go
+++ b/internal/providers/aws/client/doc.go
@@ -1,0 +1,2 @@
+// Package client provides AWS-specific client interfaces for AWS services.
+package client

--- a/internal/providers/aws/client/ecs.go
+++ b/internal/providers/aws/client/ecs.go
@@ -1,5 +1,3 @@
-// Package client provides AWS-specific client interfaces for AWS services.
-// This package contains the interfaces for the AWS clients used by the Runvoy orchestrator.
 package client
 
 import (

--- a/internal/providers/aws/constants/cloudwatch.go
+++ b/internal/providers/aws/constants/cloudwatch.go
@@ -1,4 +1,3 @@
-// Package constants provides AWS-specific constants for CloudWatch logging and events.
 package constants
 
 import (

--- a/internal/providers/aws/constants/doc.go
+++ b/internal/providers/aws/constants/doc.go
@@ -1,0 +1,2 @@
+// Package constants provides AWS-specific constants for the runvoy AWS provider.
+package constants

--- a/internal/providers/aws/constants/ecs.go
+++ b/internal/providers/aws/constants/ecs.go
@@ -1,4 +1,3 @@
-// Package constants provides AWS-specific constants for ECS task execution.
 package constants
 
 import "runvoy/internal/constants"

--- a/internal/providers/aws/constants/infra.go
+++ b/internal/providers/aws/constants/infra.go
@@ -1,4 +1,3 @@
-// Package constants provides AWS-specific constants for infrastructure deployment.
 package constants
 
 import (

--- a/internal/providers/aws/constants/logstream.go
+++ b/internal/providers/aws/constants/logstream.go
@@ -1,4 +1,3 @@
-// Package constants provides AWS-specific constants and utilities for log stream handling.
 package constants
 
 import (

--- a/internal/providers/aws/constants/logstream_test.go
+++ b/internal/providers/aws/constants/logstream_test.go
@@ -1,4 +1,3 @@
-// Package constants provides AWS-specific constants and utilities for log stream handling.
 package constants
 
 import (

--- a/internal/providers/aws/constants/secrets.go
+++ b/internal/providers/aws/constants/secrets.go
@@ -1,4 +1,3 @@
-// Package constants provides AWS-specific constants for secrets management.
 package constants
 
 // SecretsPrefix is the prefix for AWS secrets management.

--- a/internal/providers/aws/database/doc.go
+++ b/internal/providers/aws/database/doc.go
@@ -1,0 +1,2 @@
+// Package database provides AWS-specific database implementations.
+package database

--- a/internal/providers/aws/database/dynamodb/doc.go
+++ b/internal/providers/aws/database/dynamodb/doc.go
@@ -1,0 +1,2 @@
+// Package dynamodb implements DynamoDB-based storage for runvoy.
+package dynamodb

--- a/internal/providers/aws/database/dynamodb/executions.go
+++ b/internal/providers/aws/database/dynamodb/executions.go
@@ -1,5 +1,3 @@
-// Package dynamodb implements DynamoDB-based storage for runvoy.
-// It provides persistence for execution records using AWS DynamoDB.
 package dynamodb
 
 import (

--- a/internal/providers/aws/database/dynamodb/images.go
+++ b/internal/providers/aws/database/dynamodb/images.go
@@ -1,5 +1,3 @@
-// Package dynamodb implements DynamoDB-based storage for runvoy.
-// It provides persistence for image-taskdef mappings using AWS DynamoDB.
 package dynamodb
 
 import (

--- a/internal/providers/aws/database/secrets.go
+++ b/internal/providers/aws/database/secrets.go
@@ -1,5 +1,3 @@
-// Package database provides AWS-specific database implementations.
-// This file contains a SecretsRepository that coordinates DynamoDB and Parameter Store.
 package database
 
 import (

--- a/internal/providers/aws/doc.go
+++ b/internal/providers/aws/doc.go
@@ -1,0 +1,2 @@
+// Package aws contains AWS-specific configuration helpers for Runvoy services.
+package aws

--- a/internal/providers/aws/health/doc.go
+++ b/internal/providers/aws/health/doc.go
@@ -1,0 +1,2 @@
+// Package health provides AWS-specific health management implementation for runvoy.
+package health

--- a/internal/providers/aws/health/manager.go
+++ b/internal/providers/aws/health/manager.go
@@ -1,5 +1,3 @@
-// Package health provides AWS-specific health management implementation for runvoy.
-// It reconciles resources between DynamoDB metadata and actual AWS services.
 package health
 
 import (

--- a/internal/providers/aws/health/manager_test.go
+++ b/internal/providers/aws/health/manager_test.go
@@ -1,5 +1,3 @@
-// Package health provides AWS-specific health management implementation for runvoy.
-// This file contains tests for the health manager.
 package health
 
 import (

--- a/internal/providers/aws/orchestrator/doc.go
+++ b/internal/providers/aws/orchestrator/doc.go
@@ -1,0 +1,2 @@
+// Package orchestrator provides AWS-specific implementations for runvoy orchestrator.
+package orchestrator

--- a/internal/providers/aws/orchestrator/image_manager.go
+++ b/internal/providers/aws/orchestrator/image_manager.go
@@ -1,5 +1,3 @@
-// Package orchestrator provides AWS-specific implementations for runvoy orchestrator.
-// This file contains the ImageManager implementation for image registration and management.
 package orchestrator
 
 import (

--- a/internal/providers/aws/orchestrator/image_parser.go
+++ b/internal/providers/aws/orchestrator/image_parser.go
@@ -1,5 +1,3 @@
-// Package orchestrator provides AWS-specific implementations for runvoy orchestrator.
-// This file contains Docker image reference parsing utilities.
 package orchestrator
 
 import (

--- a/internal/providers/aws/orchestrator/images_dynamodb.go
+++ b/internal/providers/aws/orchestrator/images_dynamodb.go
@@ -1,5 +1,3 @@
-// Package orchestrator provides AWS-specific implementations for runvoy orchestrator.
-// This file contains image management using DynamoDB for image-taskdef mappings.
 package orchestrator
 
 import (

--- a/internal/providers/aws/orchestrator/log_manager.go
+++ b/internal/providers/aws/orchestrator/log_manager.go
@@ -1,5 +1,3 @@
-// Package orchestrator provides AWS-specific implementations for runvoy orchestrator.
-// This file contains the LogManager implementation for execution log retrieval.
 package orchestrator
 
 import (

--- a/internal/providers/aws/orchestrator/observability_manager.go
+++ b/internal/providers/aws/orchestrator/observability_manager.go
@@ -1,5 +1,3 @@
-// Package orchestrator provides AWS-specific implementations for runvoy orchestrator.
-// This file contains the ObservabilityManager implementation for backend log retrieval.
 package orchestrator
 
 import (

--- a/internal/providers/aws/orchestrator/runner.go
+++ b/internal/providers/aws/orchestrator/runner.go
@@ -1,5 +1,3 @@
-// Package orchestrator provides AWS-specific implementations for runvoy orchestrator.
-// It handles ECS task execution and AWS service integration.
 package orchestrator
 
 import (

--- a/internal/providers/aws/orchestrator/tags.go
+++ b/internal/providers/aws/orchestrator/tags.go
@@ -1,5 +1,3 @@
-// Package orchestrator provides AWS-specific implementations for runvoy orchestrator.
-// This file contains shared tagging utilities for AWS resources.
 package orchestrator
 
 import (

--- a/internal/providers/aws/orchestrator/taskdef.go
+++ b/internal/providers/aws/orchestrator/taskdef.go
@@ -1,4 +1,3 @@
-// Package orchestrator provides AWS-specific implementations for runvoy orchestrator.
 package orchestrator
 
 import (

--- a/internal/providers/aws/secrets/doc.go
+++ b/internal/providers/aws/secrets/doc.go
@@ -1,0 +1,2 @@
+// Package secrets provides AWS Secrets Manager integration for runvoy.
+package secrets

--- a/internal/providers/aws/secrets/manager.go
+++ b/internal/providers/aws/secrets/manager.go
@@ -1,5 +1,3 @@
-// Package secrets provides secret management functionality for the Runvoy orchestrator.
-// This file contains the AWS Systems Manager Parameter Store implementation.
 package secrets
 
 import (

--- a/internal/providers/aws/secrets/manager_test.go
+++ b/internal/providers/aws/secrets/manager_test.go
@@ -1,4 +1,3 @@
-// Package secrets provides secret management functionality for the Runvoy orchestrator.
 package secrets
 
 import (

--- a/internal/providers/aws/websocket/doc.go
+++ b/internal/providers/aws/websocket/doc.go
@@ -1,0 +1,2 @@
+// Package websocket provides AWS-specific WebSocket management implementation for runvoy.
+package websocket

--- a/internal/providers/aws/websocket/manager.go
+++ b/internal/providers/aws/websocket/manager.go
@@ -1,5 +1,3 @@
-// Package websocket provides AWS-specific WebSocket management implementation for runvoy.
-// It handles connection lifecycle events via API Gateway and manages WebSocket connections in DynamoDB.
 package websocket
 
 import (

--- a/internal/secrets/doc.go
+++ b/internal/secrets/doc.go
@@ -1,0 +1,2 @@
+// Package secrets provides shared utilities for secret detection and handling.
+package secrets

--- a/internal/secrets/patterns.go
+++ b/internal/secrets/patterns.go
@@ -1,4 +1,3 @@
-// Package secrets provides shared utilities for secret detection and handling.
 package secrets
 
 import "strings"


### PR DESCRIPTION
- Created doc.go files for all packages with duplicated documentation
- Removed duplicate package comments from 69 Go files
- Each package now has documentation in a single doc.go file

This change improves generated API docs by preventing duplicate package descriptions for each file. Package documentation is now centralized per Go best practices.

Packages updated:
- api, constants (main and AWS)
- orchestrator (main and AWS)
- database (main and AWS)
- health (main and AWS)
- websocket (main and AWS)
- client (main and AWS)
- playbooks, infra, dynamodb
- secrets, processor