### PR TITLE
chore: centralize log event TTL constant

### DIFF
--- a/internal/providers/aws/constants/dynamodb.go
+++ b/internal/providers/aws/constants/dynamodb.go
@@ -1,5 +1,11 @@
 package constants
 
+import "time"
+
 // DefaultExecutionListCapacity is the initial slice capacity used when listing
 // executions from DynamoDB without an explicit limit.
 const DefaultExecutionListCapacity = 16
+
+// LogEventExpirationDelay is the duration after which buffered log events are
+// marked for deletion via TTL.
+const LogEventExpirationDelay = 10 * time.Minute

--- a/internal/providers/aws/database/dynamodb/log_events.go
+++ b/internal/providers/aws/database/dynamodb/log_events.go
@@ -11,6 +11,7 @@ import (
 	"runvoy/internal/database"
 	appErrors "runvoy/internal/errors"
 	"runvoy/internal/logger"
+	awsconstants "runvoy/internal/providers/aws/constants"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
@@ -26,8 +27,7 @@ type LogEventRepository struct {
 }
 
 const (
-	logEventTTLAttribute    = "expires_at"
-	logEventExpirationDelay = 10 * time.Minute
+	logEventTTLAttribute = "expires_at"
 )
 
 // NewLogEventRepository constructs a new repository for storing execution log events.
@@ -103,7 +103,7 @@ func (r *LogEventRepository) DeleteLogEvents(ctx context.Context, executionID st
 		":execution_id": &types.AttributeValueMemberS{Value: executionID},
 	}
 
-	expiryTimestamp := time.Now().Add(logEventExpirationDelay).Unix()
+	expiryTimestamp := time.Now().Add(awsconstants.LogEventExpirationDelay).Unix()
 
 	var startKey map[string]types.AttributeValue
 


### PR DESCRIPTION
## Summary
- move the log event expiration delay constant into the AWS constants package for reuse
- use the shared constant when scheduling DynamoDB log events for TTL-based cleanup

## Testing
- `just check` *(fails: command not found in container)*
- `go test ./internal/providers/aws/database/dynamodb -run TestLogEventRepository_DeleteLogEventsSetsTTL -count=1 -timeout 30s -v` *(terminated manually after hang)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69282d21dd64832095388dff88967131)