### PR TITLE
Align webapp versioning with SvelteKit configuration

### DIFF
--- a/cmd/webapp/src/routes/+layout.svelte
+++ b/cmd/webapp/src/routes/+layout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { version } from '$app/environment';
     import ConnectionManager from '../components/ConnectionManager.svelte';
     import ViewSwitcher from '../components/ViewSwitcher.svelte';
     import { apiEndpoint, apiKey } from '../stores/config';
@@ -12,7 +13,6 @@
         disabled?: boolean;
     }
 
-    const appVersion = import.meta.env.VITE_RUNVOY_VERSION || '';
     let isConfigured = false;
 
     const views: NavView[] = [
@@ -40,8 +40,8 @@
                 <h1>
                     <img src="/runvoy-avatar.png" alt="runvoy logo" class="avatar" />
                     <div>
-                        {#if appVersion}
-                            <span class="version">{appVersion}</span>
+                        {#if version}
+                            <span class="version">{version}</span>
                         {/if}
                         <p class="subtitle">
                             <a href="https://runvoy.site/" target="_blank" rel="noopener">

--- a/cmd/webapp/src/views/SettingsView.svelte
+++ b/cmd/webapp/src/views/SettingsView.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { version } from '$app/environment';
     import { onMount } from 'svelte';
     import { apiEndpoint, apiKey } from '../stores/config';
     import APIClient from '../lib/api';
@@ -6,8 +7,6 @@
 
     export let apiClient: APIClient | null = null;
     export let isConfigured = false;
-
-    const appVersion = import.meta.env.VITE_RUNVOY_VERSION || 'unknown';
 
     let showApiKey = false;
     let backendHealth: HealthResponse | null = null;
@@ -80,7 +79,7 @@
         </div>
         <div class="info-group">
             <div class="label">Webapp Version:</div>
-            <span class="value">{appVersion}</span>
+            <span class="value">{version || 'unknown'}</span>
         </div>
         <div class="info-group">
             <div class="label">Backend Version:</div>

--- a/cmd/webapp/svelte.config.js
+++ b/cmd/webapp/svelte.config.js
@@ -1,20 +1,44 @@
 import adapter from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const appVersion = (() => {
+        if (process.env.RUNVOY_VERSION) {
+                return process.env.RUNVOY_VERSION;
+        }
+
+        if (process.env.VITE_RUNVOY_VERSION) {
+                return process.env.VITE_RUNVOY_VERSION;
+        }
+
+        try {
+                return readFileSync(join(__dirname, '../../VERSION'), 'utf-8').trim();
+        } catch (error) {
+                return '';
+        }
+})();
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	preprocess: vitePreprocess(),
-	kit: {
-		adapter: adapter({
-			pages: 'dist',
-			assets: 'dist',
-			precompress: false,
-			strict: true
-		}),
-		prerender: {
-			handleHttpError: 'warn'
-		}
-	}
+        preprocess: vitePreprocess(),
+        kit: {
+                adapter: adapter({
+                        pages: 'dist',
+                        assets: 'dist',
+                        precompress: false,
+                        strict: true
+                }),
+                version: {
+                        name: appVersion
+                },
+                prerender: {
+                        handleHttpError: 'warn'
+                }
+        }
 };
 
 export default config;

--- a/cmd/webapp/vite.config.js
+++ b/cmd/webapp/vite.config.js
@@ -1,22 +1,7 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
-import { readFileSync } from 'fs';
-import { join } from 'path';
-
-// Read version from VERSION file if VITE_RUNVOY_VERSION is not set
-if (!process.env.VITE_RUNVOY_VERSION) {
-	try {
-		const versionPath = join(__dirname, '../../VERSION');
-		const version = readFileSync(versionPath, 'utf-8').trim();
-		process.env.VITE_RUNVOY_VERSION = version;
-	} catch (error) {
-		// VERSION file not found, leave it empty
-		process.env.VITE_RUNVOY_VERSION = '';
-	}
-}
-
 export default defineConfig({
-	plugins: [sveltekit()]
+        plugins: [sveltekit()]
 });
 
 


### PR DESCRIPTION
## Summary
- derive the app version through SvelteKit's `kit.version` using environment variables or the repository VERSION file
- render the webapp version directly from `$app/environment` in layout and settings
- simplify the Vite config now that manual version injection is handled by SvelteKit

## Testing
- just check *(fails: `just` not available in container and package installation blocked by repository access restrictions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929037542948320a82056af25cc2831)