### PR TITLE
Fix webapp claim flow redirect for missing endpoint

### DIFF
--- a/cmd/webapp/src/routes/+layout.svelte
+++ b/cmd/webapp/src/routes/+layout.svelte
@@ -29,21 +29,30 @@
     $: hasEndpoint = Boolean($apiEndpoint);
     $: hasApiKey = Boolean($apiKey);
 
-    $: navViews = views.map((view) =>
-        view.id === VIEWS.LOGS || view.id === VIEWS.LIST ? { ...view, disabled: !hasApiKey } : view
-    );
+    $: navViews = views.map((view) => {
+        if (!hasEndpoint && view.id !== VIEWS.SETTINGS) {
+            return { ...view, disabled: true };
+        }
+
+        if (view.id === VIEWS.LOGS || view.id === VIEWS.LIST) {
+            return { ...view, disabled: !hasApiKey };
+        }
+
+        return view;
+    });
 
     $: {
         const pathname = $page.url.pathname;
-        const isSettingsOrClaim = pathname === '/settings' || pathname === '/claim';
+        const isSettings = pathname === '/settings';
+        const isClaim = pathname === '/claim';
 
-        // Redirect to settings if endpoint is missing (unless already on settings/claim)
-        if (!hasEndpoint && !isSettingsOrClaim) {
+        // Redirect to settings if endpoint is missing (unless already on settings)
+        if (!hasEndpoint && !isSettings) {
             goto('/settings');
         }
         // Redirect to settings if API key is missing (unless on settings/claim)
         // This allows claim view to work with just endpoint configured
-        else if (!hasApiKey && !isSettingsOrClaim) {
+        else if (!hasApiKey && !isSettings && !isClaim) {
             goto('/settings');
         }
     }

--- a/cmd/webapp/src/routes/layout.test.ts
+++ b/cmd/webapp/src/routes/layout.test.ts
@@ -1,0 +1,80 @@
+/// <reference types="vitest" />
+/// <reference types="@testing-library/jest-dom" />
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/svelte';
+
+import Layout from './+layout.svelte';
+
+const mockGoto = vi.hoisted(() => vi.fn());
+
+const createMockStore = vi.hoisted(() => {
+    return <T>(initial: T) => {
+        let value = initial;
+        const subscribers = new Set<(current: T) => void>();
+
+        return {
+            set: (newValue: T) => {
+                value = newValue;
+                subscribers.forEach((fn) => fn(value));
+            },
+            subscribe: (fn: (current: T) => void) => {
+                subscribers.add(fn);
+                fn(value);
+                return () => subscribers.delete(fn);
+            }
+        };
+    };
+});
+
+const page = vi.hoisted(() =>
+    createMockStore({
+        url: new URL('http://localhost:5173/')
+    })
+);
+
+const apiEndpoint = vi.hoisted(() => createMockStore(''));
+const apiKey = vi.hoisted(() => createMockStore(''));
+
+vi.mock('$app/navigation', () => ({
+    goto: mockGoto
+}));
+
+vi.mock('$app/environment', () => ({
+    version: 'test-version'
+}));
+
+vi.mock('$app/stores', () => ({
+    page
+}));
+
+vi.mock('../stores/config', () => ({
+    apiEndpoint,
+    apiKey
+}));
+
+describe('App layout guardrails', () => {
+    beforeEach(() => {
+        mockGoto.mockReset();
+        apiEndpoint.set('');
+        apiKey.set('');
+        page.set({ url: new URL('http://localhost:5173/') });
+    });
+
+    it('redirects to settings when no endpoint is configured', async () => {
+        page.set({ url: new URL('http://localhost:5173/claim') });
+
+        render(Layout, { slots: { default: '<p>content</p>' } });
+
+        await waitFor(() => expect(mockGoto).toHaveBeenCalledWith('/settings'));
+    });
+
+    it('allows claim view when endpoint exists but API key is missing', async () => {
+        page.set({ url: new URL('http://localhost:5173/claim') });
+        apiEndpoint.set('https://api.example.test');
+
+        render(Layout, { slots: { default: '<p>content</p>' } });
+
+        await waitFor(() => expect(mockGoto).not.toHaveBeenCalled());
+    });
+});


### PR DESCRIPTION
## Summary
- redirect users to settings when no API endpoint is configured, even from the claim view, and disable navigation until configured
- allow claim view to operate without an API key and add layout tests covering the guardrails

## Testing
- npm run test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929aaaabd8083208570776c5377e35d)