### PR TITLE
Refresh backend health after saving settings

### DIFF
--- a/cmd/webapp/src/views/SettingsView.svelte
+++ b/cmd/webapp/src/views/SettingsView.svelte
@@ -69,7 +69,7 @@
         keyInput = '';
     }
 
-    function saveConfiguration(): void {
+    async function saveConfiguration(): Promise<void> {
         formError = '';
         formSuccess = '';
 
@@ -97,6 +97,10 @@
         keyInput = '';
 
         window.dispatchEvent(new CustomEvent('credentials-updated'));
+
+        if (apiClient) {
+            await fetchBackendHealth();
+        }
     }
 
     function copyToClipboard(text: string | null): void {

--- a/cmd/webapp/src/views/SettingsView.test.ts
+++ b/cmd/webapp/src/views/SettingsView.test.ts
@@ -77,6 +77,45 @@ describe('SettingsView', () => {
         });
     });
 
+    it('fetches backend health after saving configuration', async () => {
+        const mockHealth: HealthResponse = {
+            status: 'OK',
+            version: '1.0.0'
+        };
+
+        vi.mocked(mockApiClient.getHealth as any).mockResolvedValue(mockHealth);
+
+        render(SettingsView, {
+            props: {
+                apiClient: mockApiClient as APIClient,
+                isConfigured: true
+            }
+        });
+
+        await waitFor(() => {
+            expect(mockApiClient.getHealth).toHaveBeenCalled();
+        });
+
+        const initialCallCount = vi.mocked(mockApiClient.getHealth as any).mock.calls.length;
+
+        const endpointField = screen.getByPlaceholderText('https://api.runvoy.example.com');
+        const apiKeyField = screen.getByPlaceholderText('Enter API key (or claim one later)');
+
+        await fireEvent.input(endpointField, {
+            target: { value: 'https://api.example.com' }
+        });
+
+        await fireEvent.input(apiKeyField, {
+            target: { value: 'updated-key' }
+        });
+
+        await fireEvent.click(screen.getByText('Save configuration'));
+
+        await waitFor(() => {
+            expect(mockApiClient.getHealth).toHaveBeenCalledTimes(initialCallCount + 1);
+        });
+    });
+
     it('validates the endpoint before saving', async () => {
         render(SettingsView, {
             props: {


### PR DESCRIPTION
## Summary
- trigger a backend health request when saving settings
- add coverage to ensure the save action rechecks health

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929b0cb730c8320b432a34646797536)