### PR TITLE
Remove redundant execution ID store

### DIFF
--- a/cmd/webapp/src/routes/logs/+page.svelte
+++ b/cmd/webapp/src/routes/logs/+page.svelte
@@ -3,7 +3,7 @@
     import { page } from '$app/state';
     import LogsView from '../../views/LogsView.svelte';
     import { apiClient } from '../../stores/apiClient';
-    import { lastViewedExecutionId } from '../../stores/execution';
+    import { executionId } from '../../stores/execution';
 
     // Get execution ID from URL - this is the single source of truth
     const urlExecutionId = $derived(
@@ -15,8 +15,8 @@
 
     // Restore from store if URL has no execution ID
     $effect(() => {
-        if (!urlExecutionId && $lastViewedExecutionId) {
-            goto(`/logs?execution_id=${encodeURIComponent($lastViewedExecutionId)}`, {
+        if (!urlExecutionId && $executionId) {
+            goto(`/logs?execution_id=${encodeURIComponent($executionId)}`, {
                 replaceState: true
             });
         }
@@ -25,7 +25,7 @@
     // Save to store when viewing an execution
     $effect(() => {
         if (urlExecutionId) {
-            lastViewedExecutionId.set(urlExecutionId);
+            executionId.set(urlExecutionId);
         }
     });
 </script>

--- a/cmd/webapp/src/stores/execution.ts
+++ b/cmd/webapp/src/stores/execution.ts
@@ -4,10 +4,5 @@
  */
 import { writable } from 'svelte/store';
 
+// Tracks the current/most recent execution ID so it can be reused across navigations.
 export const executionId = writable<string | null>(null);
-
-/**
- * Last viewed execution ID - persists across page navigations.
- * Used to restore the execution ID when returning to /logs without a query param.
- */
-export const lastViewedExecutionId = writable<string | null>(null);


### PR DESCRIPTION
## Summary
- remove the extra execution ID store and reuse the main executionId store for restoring the logs page

## Testing
- `just check` *(fails: command not found: just)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f9a611af88320848d69b123eeac91)