### PR TITLE
Streamline webapp layout spacing

### DIFF
--- a/cmd/webapp/src/components/ViewSwitcher.svelte
+++ b/cmd/webapp/src/components/ViewSwitcher.svelte
@@ -55,24 +55,26 @@
 <style>
     .view-switcher {
         display: flex;
-        gap: 0.5rem;
+        gap: 0.4rem;
         flex-wrap: wrap;
         align-items: center;
+        justify-content: flex-end;
     }
 
     a {
-        border-radius: var(--pico-border-radius);
-        padding: 0.5rem 1rem;
+        border-radius: 999px;
+        padding: 0.4rem 0.9rem;
         border: 1px solid var(--pico-border-color);
-        background: transparent;
+        background: color-mix(in srgb, var(--pico-background-color) 90%, var(--pico-primary) 5%);
         color: inherit;
         cursor: pointer;
-        font-weight: 500;
-        font-size: 0.9375rem;
+        font-weight: 600;
+        font-size: 0.9rem;
         transition:
             background-color 0.15s ease,
             color 0.15s ease,
-            border-color 0.15s ease;
+            border-color 0.15s ease,
+            transform 0.15s ease;
         white-space: nowrap;
         text-decoration: none;
         display: inline-block;
@@ -82,6 +84,7 @@
         border-color: var(--pico-primary);
         color: var(--pico-primary);
         background: var(--pico-primary-background);
+        transform: translateY(-1px);
     }
 
     a.active {

--- a/cmd/webapp/src/routes/+layout.svelte
+++ b/cmd/webapp/src/routes/+layout.svelte
@@ -53,22 +53,19 @@
 </script>
 
 <main class="container">
-    <header class="app-header">
-        <div class="header-content">
-            <div class="header-title">
-                <h1>
-                    <img src="/runvoy-avatar.png" alt="runvoy logo" class="avatar" />
-                    <div>
-                        {#if version}
-                            <span class="version">{version}</span>
-                        {/if}
-                        <p class="subtitle">
-                            <a href="https://runvoy.site/" target="_blank" rel="noopener">
-                                Documentation
-                            </a>
-                        </p>
-                    </div>
-                </h1>
+    <header class="app-bar">
+        <div class="brand">
+            <img src="/runvoy-avatar.png" alt="runvoy logo" class="avatar" />
+            <div class="brand-text">
+                <p class="brand-name">runvoy</p>
+                <div class="meta">
+                    {#if version}
+                        <span class="version">{version}</span>
+                    {/if}
+                    <a class="docs-link" href="https://runvoy.site/" target="_blank" rel="noopener">
+                        Documentation
+                    </a>
+                </div>
             </div>
         </div>
         <div class="header-nav">
@@ -86,75 +83,93 @@
 <style>
     /* Pico's .container class on main element handles max-width and centering */
 
-    .app-header {
-        margin-bottom: 2rem;
-        border-bottom: 1px solid var(--pico-border-color);
-        padding-bottom: 1.5rem;
-    }
-
-    .header-content {
+    .app-bar {
         display: flex;
-        gap: 1.5rem;
         align-items: center;
         justify-content: space-between;
-        margin-bottom: 1.5rem;
+        gap: 1rem;
+        padding: 0.75rem 0;
+        border-bottom: 1px solid var(--pico-border-color);
+        position: sticky;
+        top: 0;
+        background: var(--pico-background-color);
+        z-index: 5;
     }
 
-    .header-title h1 {
-        margin-bottom: 0.25rem;
-        font-size: 1.75rem;
+    .brand {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        min-width: 0;
+    }
+
+    .brand-text {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+    }
+
+    .brand-name {
+        margin: 0;
+        font-weight: 700;
+        font-size: 1.05rem;
+        letter-spacing: 0.01em;
+    }
+
+    .meta {
         display: flex;
         align-items: center;
         gap: 0.5rem;
+        flex-wrap: wrap;
     }
 
     .avatar {
-        height: 3em;
-        width: 3em;
+        height: 2.5rem;
+        width: 2.5rem;
         object-fit: contain;
-        vertical-align: middle;
     }
 
     .version {
         color: var(--pico-muted-color);
         font-size: 0.75rem;
-        /* font-weight: normal;
-        margin-left: 0.5rem; */
+        border: 1px solid var(--pico-border-color);
+        border-radius: 999px;
+        padding: 0.2rem 0.65rem;
+        background: var(--pico-primary-background);
     }
 
-    .subtitle {
-        margin: 0;
+    .docs-link {
         color: var(--pico-muted-color);
+        text-decoration: none;
         font-size: 0.875rem;
     }
 
-    .subtitle a {
-        color: var(--pico-muted-color);
-        text-decoration: none;
-    }
-
-    .subtitle a:hover {
-        text-decoration: underline;
+    .docs-link:hover {
         color: var(--pico-primary);
+        text-decoration: underline;
     }
 
     .header-nav {
-        margin-top: 1rem;
+        display: flex;
+        justify-content: flex-end;
+        width: min(640px, 100%);
     }
 
     .content-area {
         min-height: 400px;
+        padding-top: 0.5rem;
     }
 
     @media (max-width: 768px) {
-        .header-content {
-            flex-direction: column;
-            align-items: flex-start;
-            gap: 1rem;
+        .app-bar {
+            flex-wrap: wrap;
+            padding: 0.5rem 0;
+            gap: 0.75rem;
         }
 
-        .header-title h1 {
-            font-size: 1.5rem;
+        .header-nav {
+            width: 100%;
+            justify-content: flex-start;
         }
     }
 </style>

--- a/cmd/webapp/src/styles/global.css
+++ b/cmd/webapp/src/styles/global.css
@@ -7,7 +7,7 @@
     font-size: 0.875rem;
     line-height: 1.5;
     padding: 1rem;
-    height: calc(100vh - 280px);
+    height: calc(100vh - 220px);
     min-height: 400px;
     overflow-y: auto;
     white-space: pre-wrap;
@@ -21,7 +21,7 @@
     .log-container {
         font-size: 0.8125rem;
         padding: 0.75rem;
-        height: calc(100vh - 320px);
+        height: calc(100vh - 260px);
         min-height: 300px;
     }
 }


### PR DESCRIPTION
## Summary
- compress the webapp header into a sticky, compact brand bar with inline navigation
- restyle the view switcher controls for tighter spacing while keeping active/disabled cues
- increase the log viewer viewport by reducing the vertical offset

## Testing
- just check *(fails: `just` command not found in environment)*
- npm run test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935c8feddbc832094297ed33c52a389)