### PR TITLE
fix: preserve logs execution id across routes

### DIFF
--- a/cmd/webapp/src/views/LogsView.svelte
+++ b/cmd/webapp/src/views/LogsView.svelte
@@ -36,17 +36,17 @@
     $effect(() => {
         const id = currentExecutionId;
 
-        // Sync to store for child components that read it
-        executionIdStore.set(id);
-
-        if (!id) {
-            logsManager.reset();
+        // Only update the store when we actually have an execution ID.
+        // Leaving the previous value intact allows it to survive navigation
+        // between routes until an explicit ID is provided again.
+        if (id) {
+            executionIdStore.set(id);
+            logsManager.loadExecution(id);
             killer.reset();
             return;
         }
 
-        // Load the execution (manager handles deduplication internally)
-        logsManager.loadExecution(id);
+        logsManager.reset();
         killer.reset();
     });
 

--- a/cmd/webapp/src/views/LogsView.test.ts
+++ b/cmd/webapp/src/views/LogsView.test.ts
@@ -243,7 +243,7 @@ describe('LogsView', () => {
             });
         });
 
-        it('should set store to null when no execution ID', async () => {
+        it('should keep existing store value when no execution ID is provided', async () => {
             // First set an execution ID
             executionId.set('exec-old');
 
@@ -255,9 +255,9 @@ describe('LogsView', () => {
             });
 
             await waitFor(() => {
-                let storeValue: string | null = 'not-null';
+                let storeValue: string | null = null;
                 executionId.subscribe((v) => (storeValue = v))();
-                expect(storeValue).toBeNull();
+                expect(storeValue).toBe('exec-old');
             });
         });
     });


### PR DESCRIPTION
## Summary
- keep the executionId store unchanged when the logs view mounts without an id so the selection persists across navigation
- update the logs view tests to cover the persistence behavior

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935db18ebd08320b599854c5a4e38be)