### PR TITLE
docs: add user role overview to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Bootstrap the backend infrastructure and seed the admin user:
 runvoy infra apply --configure --seed-admin-user admin@example.com
 ```
 
-#### 👤 Creating a new user
+### 👤 Creating a new user
 
 The admin API key and endpoint are automatically configured in `~/.runvoy/config.yaml` after deployment. Start using runvoy immediately:
 
@@ -196,7 +196,16 @@ to create a new user account for a team member. This will generate a claim token
 - ⏱  Claim tokens expire after 15 minutes
 - 👁  Each token can only be used once
 
-Runvoy ships with default roles enforced by Casbin: admins can do everything, operators can manage executions, images, secrets, and read users, developers can run commands and manage secrets without accessing user management, viewers can only read executions, and owners automatically get full control of resources they create. See the [policy.csv](internal/auth/authorization/casbin/policy.csv) file for the exact rule set.
+### Roles
+
+Runvoy ships with default roles:
+
+- `admin` can do everything
+- `operator` can manage executions, images, secrets, and read users
+- `developer` can run commands and manage secrets without accessing user management
+- `viewer` can only read executions
+
+See the Casbin [policy.csv](internal/auth/authorization/casbin/policy.csv) file for the exact rule set.
 
 ## 📖 Usage
 
@@ -210,7 +219,7 @@ runvoy --help
 ```
 
 ```text
-runvoy - v0.5.0-20251211-3c1a8565
+runvoy - v0.5.0-20251212-21401e2a
 Isolated, repeatable execution environments for your commands
 
 Usage:


### PR DESCRIPTION
## Summary
- describe the default user roles and link to the Casbin policy file in README

## Testing
- just check *(fails: `read` function unavailable in current just version)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c0195db788320ae3b8c29f9445cef)